### PR TITLE
fix variable defaulted event to only be logged when variable does not exist in config

### DIFF
--- a/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
@@ -75,7 +75,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
                 returnVariable.Value = variable.Value;
                 returnVariable.Type = variable.Type;
                 returnVariable.EvalReason = variable.EvalReason;
-                returnVariable.IsDefaulted = variable.IsDefaulted;
+                returnVariable.IsDefaulted = false;
             }
             else
             {

--- a/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
@@ -111,7 +111,7 @@ namespace DevCycle.SDK.Server.Local.Api
 
             var variable =  SDK.Server.Common.Model.Local.Variable<T>.InitializeFromVariable(existingVariable, key, defaultValue);
 
-            var @event = new Event(type: variable.Value.Equals(variable.DefaultValue)
+            var @event = new Event(type: variable.IsDefaulted
                     ? EventTypes.variableDefaulted
                     : EventTypes.variableEvaluated,
                 target: variable.Key);


### PR DESCRIPTION
A variable value being the same as the default value does not mean the variable was defaulted