### PR TITLE
update event queue to group by featureVars and full user data

### DIFF
--- a/DevCycle.SDK.Server.Common/Model/Local/DVCPopulatedUser.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/DVCPopulatedUser.cs
@@ -69,6 +69,8 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         [JsonProperty("deviceModel")]
         public readonly string DeviceModel;
 
+        private readonly int hashCode;
+
         public DVCPopulatedUser(User user)
         {
             if (user == null)
@@ -79,6 +81,8 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             {
                 throw new ArgumentException("Must have a UserId set on the user");
             }
+
+            hashCode = user.GetHashCode();
 
             UserId = user.UserId;
             Email = user.Email;
@@ -103,6 +107,16 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         public virtual string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+
+        public override int GetHashCode()
+        {
+            return hashCode;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return hashCode == obj?.GetHashCode();
         }
     }
 }

--- a/DevCycle.SDK.Server.Common/Model/Local/DVCPopulatedUser.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/DVCPopulatedUser.cs
@@ -19,28 +19,28 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         
         [DataMember(Name="email", EmitDefaultValue=false)]
         [JsonProperty("email")]
-        public string Email;
+        public readonly string Email;
         [DataMember(Name="name", EmitDefaultValue=false)]
         [JsonProperty("name")]
-        public string Name;
+        public readonly string Name;
         [DataMember(Name = "language", EmitDefaultValue = false)]
         [JsonProperty("language")]
-        public string Language;
+        public readonly string Language;
         [DataMember(Name = "country", EmitDefaultValue = false)]
         [JsonProperty("country")]
-        public string Country;
+        public readonly string Country;
         [DataMember(Name = "appVersion", EmitDefaultValue = false)]
         [JsonProperty("appVersion")]
-        public string AppVersion;
+        public readonly string AppVersion;
         [DataMember(Name = "appBuild", EmitDefaultValue = false)]
         [JsonProperty("appBuild")]
-        public int AppBuild;
+        public readonly int AppBuild;
         [DataMember(Name = "customData", EmitDefaultValue = false)]
         [JsonProperty("customData")]
-        public object CustomData;
+        public readonly object CustomData;
         [DataMember(Name = "privateCustomData", EmitDefaultValue = false)]
         [JsonProperty("privateCustomData")]
-        public object PrivateCustomData;
+        public readonly object PrivateCustomData;
 
         [DataMember(Name = "lastSeenDate", EmitDefaultValue = false)]
         [JsonProperty("lastSeenDate")]

--- a/DevCycle.SDK.Server.Common/Model/Local/DVCRequestEvent.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/DVCRequestEvent.cs
@@ -13,33 +13,33 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         private readonly List<string> eventTypes = new List<string> {VariableEvaluated, VariableDefaulted};
         
         [DataMember(Name="type", EmitDefaultValue=false)]
-        public string Type { get; private set; }
+        public string Type { get; }
         
         [DataMember(Name="target", EmitDefaultValue=false)]
-        public string Target { get; private set; }
+        public string Target { get; }
         
         [DataMember(Name="customType", EmitDefaultValue=false)]
-        public string CustomType { get; private set; }
+        public string CustomType { get; }
         
         [DataMember(Name="user_id", EmitDefaultValue=false)]
-        public string UserId { get; private set; }
+        public string UserId { get; }
         
         [DataMember(Name="date", EmitDefaultValue=false)]
-        public long Date { get; private set; }
+        public long Date { get; }
         
         [DataMember(Name="clientDate", EmitDefaultValue=false)]
-        public long? ClientDate { get; private set; }
+        public long? ClientDate { get; }
         
         [DataMember(Name="value", EmitDefaultValue=false)]
         public decimal? Value { get; set; }
         
         [DataMember(Name="featureVars", EmitDefaultValue=false)]
-        public Dictionary<string, string> FeatureVars { get; private set; }
+        public Dictionary<string, string> FeatureVars { get; }
         
         [DataMember(Name="metaData", EmitDefaultValue=false)]
-        public Dictionary<string, object> MetaData { get; private set; }
+        public Dictionary<string, object> MetaData { get; }
         
-        public bool IsCustomEvent { get; private set; }
+        public bool IsCustomEvent { get; }
 
         public DVCRequestEvent(Event @event, string userId, Dictionary<string, string> featureVars)
         {

--- a/DevCycle.SDK.Server.Common/Model/Local/UserEventsBatchRecord.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/UserEventsBatchRecord.cs
@@ -7,7 +7,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
     public class UserEventsBatchRecord
     {
         [DataMember(Name="user", EmitDefaultValue=false)]
-        public DVCPopulatedUser User { get; set; }
+        public DVCPopulatedUser User { get; }
         
         [DataMember(Name="events", EmitDefaultValue=false)]
         public List<DVCRequestEvent> Events { get; private set; }

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycle.SDK.Server.Local.MSTests.csproj
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycle.SDK.Server.Local.MSTests.csproj
@@ -5,8 +5,8 @@
     <IsPackable>false</IsPackable>
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Local.Api;
@@ -163,7 +161,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
         }
         
         [TestMethod]
-        public async Task QueueTwoAggregateEvents_EventsQueuedSuccessfully()
+        public async Task QueueAggregateEvents_EventsQueuedSuccessfully()
         {
             // Mock EventQueue for verification without mocking any methods
             var mockedQueue = new Mock<EventQueue>

--- a/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Local.Api;
@@ -132,10 +134,13 @@ namespace DevCycle.SDK.Server.Local.MSTests
             // add delay so the queue should still be looping trying to flush
             await Task.Delay(100);
             mockedQueue.Verify(m => m.FlushEvents(), Times.AtLeastOnce);
+            dvcEventsApiClient.Verify(m => m.PublishEvents(It.IsAny<BatchOfUserEventsBatch>()), Times.AtLeastOnce);
 
             // ensure the queue can now be flushed
-            mockedQueue.Invocations.Clear();
             mockResponse.SetupGet( _ => _.StatusCode).Returns(HttpStatusCode.Created);
+            
+            mockedQueue.Invocations.Clear();
+            dvcEventsApiClient.Invocations.Clear();
             
             mockedQueue.Object.RemoveFlushedEventsSubscriber(AssertFalseFlushedEvents);
             mockedQueue.Object.AddFlushedEventsSubscriber(AssertTrueFlushedEvents);
@@ -144,10 +149,21 @@ namespace DevCycle.SDK.Server.Local.MSTests
             await Task.Delay(500);
 
             mockedQueue.Verify(m => m.FlushEvents(), Times.AtMost(2));
+            dvcEventsApiClient.Verify(m => m.PublishEvents(It.IsAny<BatchOfUserEventsBatch>()), Times.AtMost(2));
+            
+            // internal event queue should now be empty, flush events manually and check that publish isnt called
+            
+            mockedQueue.Invocations.Clear();
+            dvcEventsApiClient.Invocations.Clear();
+            await mockedQueue.Object.FlushEvents();
+            await Task.Delay(20);
+            
+            mockedQueue.Verify(m => m.FlushEvents(), Times.Once);
+            dvcEventsApiClient.Verify(m => m.PublishEvents(It.IsAny<BatchOfUserEventsBatch>()), Times.Never());
         }
         
         [TestMethod]
-        public void QueueTwoAggregateEvents_EventsQueuedSuccessfully()
+        public async Task QueueTwoAggregateEvents_EventsQueuedSuccessfully()
         {
             // Mock EventQueue for verification without mocking any methods
             var mockedQueue = new Mock<EventQueue>
@@ -156,26 +172,53 @@ namespace DevCycle.SDK.Server.Local.MSTests
             };
             
             var mockResponse = new Mock<IRestResponse>();
-            mockResponse.SetupGet(_ => _.StatusCode).Returns(HttpStatusCode.InternalServerError);
+            mockResponse.SetupGet(_ => _.StatusCode).Returns(HttpStatusCode.Created);
             
             dvcEventsApiClient.Setup(m => m.PublishEvents(It.IsAny<BatchOfUserEventsBatch>()))
                 .ReturnsAsync(mockResponse.Object);
             mockedQueue.Object.SetPrivateFieldValue("dvcEventsApiClient", dvcEventsApiClient.Object);
 
-            var user = new User(userId: "1");
+            var dvcPopulatedUser = new DVCPopulatedUser(new User(userId: "1", name: "User1"));
+            var dvcPopulatedUser2 = new DVCPopulatedUser(new User(userId: "2", name: "User2"));
+            var dvcPopulatedUser3 = new DVCPopulatedUser(new User(userId: "1", name: "User3"));
 
-            var @event = new Event("VariableEvaluated", "config1");
+            var @event = new Event("variableEvaluated", target: "var1");
+            var @event2 = new Event(type: "variableEvaluated", target: "var2");
+            var @event3 = new Event(type: "variableDefaulted", target: "var2");
 
             var config = new BucketedUserConfig
             {
                 FeatureVariationMap = new Dictionary<string, string> {{"some-feature-id", "some-variation-id"}}
             };
 
-            var dvcPopulatedUser = new DVCPopulatedUser(user);
-            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event, config);
+            var config2 = new BucketedUserConfig
+            {
+                FeatureVariationMap = new Dictionary<string, string> { { "feature2", "variation2" } }
+            };
             
-            @event = new Event("VariableEvaluated", "config2");
             mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event, config);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event, config);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event2, config);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event2, config);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event3, config);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event, config2);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser2, @event, config);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser3, @event, config);
+
+            mockedQueue.Object.AddFlushedEventsSubscriber(AssertTrueFlushedEvents);
+
+            await mockedQueue.Object.FlushEvents();
+            await Task.Delay(20);
+
+            dvcEventsApiClient.Verify(m => m.PublishEvents(It.Is<BatchOfUserEventsBatch>(b =>
+               AssertAggregateEventsBatch(b)
+            )), Times.Once());
+            
+            await mockedQueue.Object.FlushEvents();
+            await Task.Delay(20);
+            // verify that it hasn't been called again because there should be nothing in the queue
+            dvcEventsApiClient.Verify(m => m.PublishEvents(It.IsAny<BatchOfUserEventsBatch>(
+            )), Times.Once());
         }
         
         private void AssertTrueFlushedEvents(object sender, DVCEventArgs e)
@@ -186,6 +229,44 @@ namespace DevCycle.SDK.Server.Local.MSTests
         private void AssertFalseFlushedEvents(object sender, DVCEventArgs e)
         {
             Assert.IsFalse(e.Success);
+        }
+
+        private bool AssertAggregateEventsBatch(BatchOfUserEventsBatch b)
+        {
+            Debug.Assert(b.UserEventsBatchRecords.Count == 3);
+            Debug.Assert(b.UserEventsBatchRecords[0].User.Name == "User1");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events.Count == 4);
+            
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[0].Type == "variableEvaluated");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[0].Target == "var1");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[0].Value == 2);
+            
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[1].Type == "variableEvaluated");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[1].Target == "var2");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[1].Value == 2);
+            
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[2].Type == "variableDefaulted");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[2].Target == "var2");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[2].Value == 1);
+            
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].Type == "variableEvaluated");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].Target == "var1");
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].Value == 1);
+            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].FeatureVars["feature2"] == "variation2");
+
+            Debug.Assert(b.UserEventsBatchRecords[1].User.Name == "User2");
+            Debug.Assert(b.UserEventsBatchRecords[1].Events.Count == 1);
+            Debug.Assert(b.UserEventsBatchRecords[1].Events[0].Type == "variableEvaluated");
+            Debug.Assert(b.UserEventsBatchRecords[1].Events[0].Target == "var1");
+            Debug.Assert(b.UserEventsBatchRecords[1].Events[0].Value == 1);
+
+            Debug.Assert(b.UserEventsBatchRecords[2].User.Name == "User3");
+            Debug.Assert(b.UserEventsBatchRecords[2].Events.Count == 1);
+            Debug.Assert(b.UserEventsBatchRecords[2].Events[0].Type == "variableEvaluated");
+            Debug.Assert(b.UserEventsBatchRecords[2].Events[0].Target == "var1");
+            Debug.Assert(b.UserEventsBatchRecords[2].Events[0].Value == 1);
+
+            return true;
         }
     }
 }

--- a/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
@@ -190,6 +190,11 @@ namespace DevCycle.SDK.Server.Local.MSTests
             {
                 FeatureVariationMap = new Dictionary<string, string> {{"some-feature-id", "some-variation-id"}}
             };
+            
+            var configIdentical = new BucketedUserConfig
+            {
+                FeatureVariationMap = new Dictionary<string, string> {{"some-feature-id", "some-variation-id"}}
+            };
 
             var config2 = new BucketedUserConfig
             {
@@ -197,7 +202,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
             };
             
             mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event, config);
-            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event, config);
+            mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event, configIdentical);
             mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event2, config);
             mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event2, config);
             mockedQueue.Object.QueueAggregateEvent(dvcPopulatedUser, @event3, config);
@@ -233,38 +238,38 @@ namespace DevCycle.SDK.Server.Local.MSTests
 
         private bool AssertAggregateEventsBatch(BatchOfUserEventsBatch b)
         {
-            Debug.Assert(b.UserEventsBatchRecords.Count == 3);
-            Debug.Assert(b.UserEventsBatchRecords[0].User.Name == "User1");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events.Count == 4);
+            Assert.IsTrue(b.UserEventsBatchRecords.Count == 3);
+            Assert.IsTrue(b.UserEventsBatchRecords[0].User.Name == "User1");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events.Count == 4);
             
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[0].Type == "variableEvaluated");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[0].Target == "var1");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[0].Value == 2);
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[0].Type == "variableEvaluated");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[0].Target == "var1");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[0].Value == 2);
             
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[1].Type == "variableEvaluated");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[1].Target == "var2");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[1].Value == 2);
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[1].Type == "variableEvaluated");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[1].Target == "var2");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[1].Value == 2);
             
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[2].Type == "variableDefaulted");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[2].Target == "var2");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[2].Value == 1);
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[2].Type == "variableDefaulted");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[2].Target == "var2");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[2].Value == 1);
             
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].Type == "variableEvaluated");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].Target == "var1");
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].Value == 1);
-            Debug.Assert(b.UserEventsBatchRecords[0].Events[3].FeatureVars["feature2"] == "variation2");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[3].Type == "variableEvaluated");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[3].Target == "var1");
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[3].Value == 1);
+            Assert.IsTrue(b.UserEventsBatchRecords[0].Events[3].FeatureVars["feature2"] == "variation2");
 
-            Debug.Assert(b.UserEventsBatchRecords[1].User.Name == "User2");
-            Debug.Assert(b.UserEventsBatchRecords[1].Events.Count == 1);
-            Debug.Assert(b.UserEventsBatchRecords[1].Events[0].Type == "variableEvaluated");
-            Debug.Assert(b.UserEventsBatchRecords[1].Events[0].Target == "var1");
-            Debug.Assert(b.UserEventsBatchRecords[1].Events[0].Value == 1);
+            Assert.IsTrue(b.UserEventsBatchRecords[1].User.Name == "User2");
+            Assert.IsTrue(b.UserEventsBatchRecords[1].Events.Count == 1);
+            Assert.IsTrue(b.UserEventsBatchRecords[1].Events[0].Type == "variableEvaluated");
+            Assert.IsTrue(b.UserEventsBatchRecords[1].Events[0].Target == "var1");
+            Assert.IsTrue(b.UserEventsBatchRecords[1].Events[0].Value == 1);
 
-            Debug.Assert(b.UserEventsBatchRecords[2].User.Name == "User3");
-            Debug.Assert(b.UserEventsBatchRecords[2].Events.Count == 1);
-            Debug.Assert(b.UserEventsBatchRecords[2].Events[0].Type == "variableEvaluated");
-            Debug.Assert(b.UserEventsBatchRecords[2].Events[0].Target == "var1");
-            Debug.Assert(b.UserEventsBatchRecords[2].Events[0].Value == 1);
+            Assert.IsTrue(b.UserEventsBatchRecords[2].User.Name == "User3");
+            Assert.IsTrue(b.UserEventsBatchRecords[2].Events.Count == 1);
+            Assert.IsTrue(b.UserEventsBatchRecords[2].Events[0].Type == "variableEvaluated");
+            Assert.IsTrue(b.UserEventsBatchRecords[2].Events[0].Target == "var1");
+            Assert.IsTrue(b.UserEventsBatchRecords[2].Events[0].Value == 1);
 
             return true;
         }

--- a/DevCycle.SDK.Server.Local/Api/AggregateEventQueues.cs
+++ b/DevCycle.SDK.Server.Local/Api/AggregateEventQueues.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using DevCycle.SDK.Server.Common.Model.Local;
+
+namespace DevCycle.SDK.Server.Local.Api;
+
+internal class AggregateEventQueues
+{
+    private readonly Dictionary<
+        UserAndFeatureVars,
+        Dictionary<string, DVCRequestEvent>> eventQueueMap;
+        
+    public AggregateEventQueues()
+    {
+        eventQueueMap = new Dictionary<UserAndFeatureVars, Dictionary<string, DVCRequestEvent>>();
+    }
+
+    public void AddEvent(UserAndFeatureVars userFeatureVars, DVCRequestEvent requestEvent)
+    {
+        if (!eventQueueMap.ContainsKey(userFeatureVars))
+        {
+            eventQueueMap[userFeatureVars] = new Dictionary<string, DVCRequestEvent>();
+        }
+
+        var eventKey = GetEventMapKey(requestEvent);
+
+        if (!eventQueueMap[userFeatureVars].ContainsKey(eventKey))
+        {
+            eventQueueMap[userFeatureVars][eventKey] = requestEvent;
+        }
+        else
+        {
+            eventQueueMap[userFeatureVars][eventKey].Value += 1;
+        }
+    }
+
+    private string GetEventMapKey(DVCRequestEvent requestEvent)
+    {
+        return requestEvent.Type + requestEvent.Target;
+    }
+
+    public Dictionary<DVCPopulatedUser, UserEventsBatchRecord> GetEventBatches()
+    {
+        // regroup aggregate events into batches by unique user
+        var userEventBatches = new Dictionary<DVCPopulatedUser, UserEventsBatchRecord>();
+            
+        foreach (var entries in eventQueueMap)
+        {
+            var user = entries.Key.User;
+            if (!userEventBatches.ContainsKey(user))
+            {
+                userEventBatches[user] = new UserEventsBatchRecord(user);
+            }
+                
+            userEventBatches[user].Events.AddRange(entries.Value.Values.ToList());
+        }
+            
+        return userEventBatches;
+    }
+
+    public void Clear()
+    {
+        eventQueueMap.Clear();
+    }
+}

--- a/DevCycle.SDK.Server.Local/Api/EventQueue.cs
+++ b/DevCycle.SDK.Server.Local/Api/EventQueue.cs
@@ -11,8 +11,92 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RestSharp.Portable;
 
+
 namespace DevCycle.SDK.Server.Local.Api
 {
+    internal class UserAndFeatureVars
+    {
+        public readonly DVCPopulatedUser User;
+        private readonly Dictionary<string, string> featureVars;
+
+        public UserAndFeatureVars(DVCPopulatedUser user, Dictionary<string, string> featureVars)
+        {
+            User = user;
+            this.featureVars = featureVars;
+        }
+
+        public override int GetHashCode()
+        {
+            var result = User.GetHashCode() + featureVars.GetHashCode();
+            return result;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return GetHashCode().Equals(obj.GetHashCode());
+        }
+    }
+
+    internal class AggregateEventQueues
+    {
+        private readonly Dictionary<
+            UserAndFeatureVars,
+            Dictionary<string, DVCRequestEvent>> eventQueueMap;
+        
+        public AggregateEventQueues()
+        {
+            eventQueueMap = new Dictionary<UserAndFeatureVars, Dictionary<string, DVCRequestEvent>>();
+        }
+
+        public void AddEvent(UserAndFeatureVars userFeatureVars, DVCRequestEvent requestEvent)
+        {
+            if (!eventQueueMap.ContainsKey(userFeatureVars))
+            {
+                eventQueueMap[userFeatureVars] = new Dictionary<string, DVCRequestEvent>();
+            }
+
+            var eventKey = GetEventMapKey(requestEvent);
+
+            if (!eventQueueMap[userFeatureVars].ContainsKey(eventKey))
+            {
+                eventQueueMap[userFeatureVars][eventKey] = requestEvent;
+            }
+            else
+            {
+                eventQueueMap[userFeatureVars][eventKey].Value += 1;
+            }
+        }
+
+        private string GetEventMapKey(DVCRequestEvent requestEvent)
+        {
+            return requestEvent.Type + requestEvent.Target;
+        }
+
+        public Dictionary<DVCPopulatedUser, UserEventsBatchRecord> GetEventBatches()
+        {
+            // regroup aggregate events into batches by unique user
+            var userEventBatches = new Dictionary<DVCPopulatedUser, UserEventsBatchRecord>();
+            
+            foreach (var entries in eventQueueMap)
+            {
+                var user = entries.Key.User;
+                if (!userEventBatches.ContainsKey(user))
+                {
+                    userEventBatches[user] = new UserEventsBatchRecord(user);
+                }
+                
+                userEventBatches[user].Events.AddRange(entries.Value.Values.ToList());
+            }
+
+            return userEventBatches;
+        }
+
+        public void Clear()
+        {
+            eventQueueMap.Clear();
+        }
+    }
+
     internal class EventQueue
     {
         private readonly DVCOptions options;
@@ -22,11 +106,13 @@ namespace DevCycle.SDK.Server.Local.Api
         
         private readonly Mutex eventQueueMutex = new();
         private readonly Mutex aggregateEventQueueMutex = new();
-
-        private readonly Dictionary<string, UserEventsBatchRecord> eventPayloadsToFlush;
+        private readonly Mutex batchQueueMutex = new();
         
-        private readonly Dictionary<string, DVCPopulatedUser> userForAggregation;
-        private readonly Dictionary<string, Dictionary<string, Dictionary<string, DVCRequestEvent>>> aggregateEvents;
+        private readonly Dictionary<DVCPopulatedUser, UserEventsBatchRecord> eventPayloadsToFlush;
+        
+        private readonly AggregateEventQueues aggregateEvents;
+
+        private readonly List<BatchOfUserEventsBatch> batchQueue = new();
 
         private readonly ILogger logger;
 
@@ -44,9 +130,8 @@ namespace DevCycle.SDK.Server.Local.Api
             dvcEventsApiClient = new DVCEventsApiClient(environmentKey);
             this.options = options;
             
-            eventPayloadsToFlush = new Dictionary<string, UserEventsBatchRecord>();
-            userForAggregation = new Dictionary<string, DVCPopulatedUser>();
-            aggregateEvents = new Dictionary<string, Dictionary<string, Dictionary<string, DVCRequestEvent>>>();
+            eventPayloadsToFlush = new Dictionary<DVCPopulatedUser, UserEventsBatchRecord>();
+            aggregateEvents = new AggregateEventQueues();
 
             logger = loggerFactory.CreateLogger<EventQueue>();
         }
@@ -70,62 +155,74 @@ namespace DevCycle.SDK.Server.Local.Api
             var eventArgs = new DVCEventArgs();
             try
             {
+                eventQueueMutex.WaitOne();
+                aggregateEventQueueMutex.WaitOne();
+                batchQueueMutex.WaitOne();
+
                 var userEventBatch = CombineUsersEventsToFlush();
-                if (userEventBatch.Count == 0)
+                if (userEventBatch.Count != 0)
+                {
+                    batchQueue.Add(new BatchOfUserEventsBatch(userEventBatch.Values.ToList()));
+                    eventPayloadsToFlush.Clear();
+                    aggregateEvents.Clear();
+                }
+                
+                eventQueueMutex.ReleaseMutex();
+                aggregateEventQueueMutex.ReleaseMutex();
+
+                if (batchQueue.Count == 0)
                 {
                     eventArgs.Success = true;
                     OnFlushedEvents(eventArgs);
                 }
 
-                eventQueueMutex.WaitOne();
-                var localEventPayloadsToFlush = eventPayloadsToFlush.ToDictionary(entry => entry.Key, 
-                    entry => entry.Value);
-                eventPayloadsToFlush.Clear();
-                eventQueueMutex.ReleaseMutex();
-
-                aggregateEventQueueMutex.WaitOne();
-                var localUserForAggregation = userForAggregation.ToDictionary(entry => entry.Key,
-                    entry => entry.Value);
-                var localAggregateEvents = aggregateEvents.ToDictionary(entry => entry.Key,
-                    entry => entry.Value);
-                userForAggregation.Clear();
-                aggregateEvents.Clear();
-                aggregateEventQueueMutex.ReleaseMutex();
-
                 var eventCount = userEventBatch.Sum(u => userEventBatch.Values.Count);
 
                 logger.LogInformation("DVC Flush {EventCount} Events, for {UserEventBatch} Users", eventCount, userEventBatch.Count);
-
-                var userEvents = userEventBatch.Select(u => u.Value).ToList();
-
+                
                 IRestResponse response = null;
+
+                var successfulRequests = new List<BatchOfUserEventsBatch>();
 
                 try
                 {
-                    BatchOfUserEventsBatch batch = new BatchOfUserEventsBatch(userEvents);
-                    response = await dvcEventsApiClient.PublishEvents(batch);
-
-                    if (response.StatusCode != HttpStatusCode.Created)
+                    foreach (var batch in batchQueue)
                     {
-                        throw new System.Exception(
-                            $"Error publishing events, status {response.StatusCode}, body: {userEvents}");
+                        response = await dvcEventsApiClient.PublishEvents(batch);
+
+                        if (response.StatusCode != HttpStatusCode.Created)
+                        {
+                            throw new System.Exception(
+                                $"Error publishing events, status {response.StatusCode}, body: {batch}");
+                        }
+                        
+                        successfulRequests.Add(batch);
                     }
+
+                    batchQueue.Clear();
+
+                    batchQueue.AddRange(batchQueue.Except(successfulRequests));
                     
-                    logger.LogDebug("DVC Flushed {EventCount} Events, for {UserEventBatch} Users", eventCount, userEventBatch.Count);
+                    logger.LogDebug("DVC Flushed {EventCount} Events, for {UserEventBatch} Users", eventCount,
+                        userEventBatch.Count);
                     eventArgs.Success = true;
                     OnFlushedEvents(eventArgs);
                 }
                 catch (System.Exception e)
                 {
-                    logger.LogError("DVC Error Flushing Events response message: {Exception}, response data: {Response}", e.Message, response.Content);
-                    
-                    RequeueUserEvents(localEventPayloadsToFlush);
-                    RequeueAggregateEvents(localUserForAggregation, localAggregateEvents);
+                    logger.LogError(
+                        "DVC Error Flushing Events response message: {Exception}, response data: {Response}", e.Message,
+                        response.Content);
+
                     ScheduleFlushWithDelay(true);
                     var dvcException = new DVCException(response.StatusCode, new ErrorResponse(e.Message));
                     eventArgs.Success = false;
                     eventArgs.Error = dvcException;
                     OnFlushedEvents(eventArgs);
+                }
+                finally
+                {
+                    batchQueueMutex.ReleaseMutex();
                 }
             }
             finally
@@ -136,15 +233,17 @@ namespace DevCycle.SDK.Server.Local.Api
 
         public virtual void QueueEvent(DVCPopulatedUser user, Event @event, BucketedUserConfig config)
         {
-            if (!eventPayloadsToFlush.ContainsKey(user.UserId))
+            eventQueueMutex.WaitOne();
+            if (!eventPayloadsToFlush.ContainsKey(user))
             {
-                eventPayloadsToFlush.Add(user.UserId, new UserEventsBatchRecord(user));
+                eventPayloadsToFlush.Add(user, new UserEventsBatchRecord(user));
             }
             
-            var userAndEvents = eventPayloadsToFlush[user.UserId];
-            userAndEvents.User = user;
+            var userAndEvents = eventPayloadsToFlush[user];
 
             userAndEvents.Events.Add(new DVCRequestEvent(@event, user.UserId, config.FeatureVariationMap));
+            
+            eventQueueMutex.ReleaseMutex();
             
             logger.LogInformation("{Event} queued successfully", @event);
             
@@ -174,89 +273,37 @@ namespace DevCycle.SDK.Server.Local.Api
             eventCopy.Date = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             eventCopy.Value = 1;
 
-            if (!userForAggregation.ContainsKey(user.UserId))
-            {
-                userForAggregation.Add(user.UserId, user);   
-            }
-            else
-            {
-                userForAggregation[user.UserId] = user;
-            }
-            
             var requestEvent = new DVCRequestEvent(
                 eventCopy, 
                 user.UserId, 
                 config == null ? new Dictionary<string, string>() : config.FeatureVariationMap
             );
             
-            AddAggregateEvent(requestEvent, user);
+            var userAndFeatureVars = new UserAndFeatureVars(user, requestEvent.FeatureVars);
 
+            aggregateEventQueueMutex.WaitOne();
+            aggregateEvents.AddEvent(userAndFeatureVars, requestEvent);
+            aggregateEventQueueMutex.ReleaseMutex();
             ScheduleFlushWithDelay();
         }
 
-        private void AddAggregateEvent(DVCRequestEvent requestEvent, DVCPopulatedUser user)
+        private Dictionary<DVCPopulatedUser, UserEventsBatchRecord> CombineUsersEventsToFlush()
         {
-            var aggregateUser = aggregateEvents.ContainsKey(user.UserId)
-                ? aggregateEvents[user.UserId]
-                : new Dictionary<string, Dictionary<string, DVCRequestEvent>>();
-
-            var aggregateEventType = aggregateUser.ContainsKey(requestEvent.Type)
-                ? aggregateUser[requestEvent.Type]
-                : AddAggregateEventType(user, aggregateUser, requestEvent);
-
-            if (aggregateEventType.ContainsKey(requestEvent.Target))
-            {
-                aggregateEventType[requestEvent.Target].Value += Decimal.One;
-            }
-            else
-            {
-                aggregateEventType.Add(requestEvent.Target, requestEvent);
-            }
-        }
-
-        private Dictionary<string, DVCRequestEvent> AddAggregateEventType(DVCPopulatedUser user,
-            Dictionary<string, Dictionary<string, DVCRequestEvent>> aggregateUser,
-            DVCRequestEvent requestEvent)
-        {
-            aggregateUser.Add(requestEvent.Type, new Dictionary<string, DVCRequestEvent>());
-            aggregateUser[requestEvent.Type].Add(requestEvent.Target, requestEvent);
-            aggregateEvents.Add(user.UserId, aggregateUser);
-
-            return aggregateUser[requestEvent.Type];
-        }
-
-        private Dictionary<string, UserEventsBatchRecord> CombineUsersEventsToFlush()
-        {
-            var userEventsBatchRecords = new Dictionary<string, UserEventsBatchRecord>();
+            var userEventsBatchRecords = aggregateEvents.GetEventBatches();
 
             foreach (var eventPayload in eventPayloadsToFlush)
             {
-                var userId = eventPayload.Key;
+                var user = eventPayload.Key;
                 var userEventsRecord = eventPayload.Value;
 
-                if (userEventsBatchRecords.ContainsKey(userId))
+                if (userEventsBatchRecords.ContainsKey(user))
                 {
-                    userEventsBatchRecords[userId].Events.AddRange(userEventsRecord.Events);
+                    userEventsBatchRecords[user].Events.AddRange(userEventsRecord.Events);
                 }
                 else
                 {
-                    userEventsBatchRecords.Add(userId, userEventsRecord);
+                    userEventsBatchRecords.Add(user, userEventsRecord);
                 }
-            }
-
-            foreach (var userEvent in userForAggregation)
-            {
-                var userId = userEvent.Key;
-                var user = userEvent.Value;
-                var aggUserEventsRecord = aggregateEvents[userId];
-                var events = EventsFromAggregateEvents(aggUserEventsRecord);
-
-                if (!userEventsBatchRecords.ContainsKey(userId))
-                {
-                    var userEventsRecord = new UserEventsBatchRecord(user);
-                    userEventsBatchRecords.Add(userId, userEventsRecord);
-                }
-                userEventsBatchRecords[userId].Events.AddRange(events);
             }
 
             return userEventsBatchRecords;
@@ -266,38 +313,6 @@ namespace DevCycle.SDK.Server.Local.Api
         {
             return (from eventType in aggUserEventsRecord 
                 from eventTarget in eventType.Value select eventTarget.Value).ToList();
-        }
-        
-        private void RequeueAggregateEvents(Dictionary<string,DVCPopulatedUser> localUserForAggregation,
-            Dictionary<string,Dictionary<string,Dictionary<string,DVCRequestEvent>>> localAggregateEvents)
-        {
-            foreach (var localUser in localUserForAggregation)
-            {
-                if (userForAggregation.ContainsKey(localUser.Key))
-                {
-                    var aggregateEvent = localAggregateEvents[localUser.Key];
-
-                    foreach (var @event in EventsFromAggregateEvents(aggregateEvent))
-                    {
-                        AddAggregateEvent(@event, localUser.Value);
-                    } 
-                }
-            }
-        }
-
-        private void RequeueUserEvents(Dictionary<string,UserEventsBatchRecord> localEventPayloadsToFlush)
-        {
-            foreach (var userEventsBatchRecord in localEventPayloadsToFlush)
-            {
-                if (eventPayloadsToFlush.ContainsKey(userEventsBatchRecord.Key))
-                {
-                    eventPayloadsToFlush[userEventsBatchRecord.Key].Events.AddRange(userEventsBatchRecord.Value.Events);
-                }
-                else
-                {
-                    eventPayloadsToFlush.Add(userEventsBatchRecord.Key, userEventsBatchRecord.Value);
-                }
-            }
         }
 
         private void ScheduleFlushWithDelay(bool queueRequest = false)

--- a/DevCycle.SDK.Server.Local/Api/EventQueue.cs
+++ b/DevCycle.SDK.Server.Local/Api/EventQueue.cs
@@ -25,15 +25,26 @@ namespace DevCycle.SDK.Server.Local.Api
             this.featureVars = featureVars;
         }
 
+        private int FeatureVarsHashCode()
+        {
+            var sum = 0;
+            foreach (var entry in featureVars)
+            {
+                sum += entry.Key.GetHashCode();
+                sum += entry.Value.GetHashCode();
+            }
+
+            return sum;
+        }
+
         public override int GetHashCode()
         {
-            var result = User.GetHashCode() + featureVars.GetHashCode();
-            return result;
+            return User.GetHashCode() + FeatureVarsHashCode();
         }
 
         public override bool Equals(object obj)
         {
-            return GetHashCode().Equals(obj.GetHashCode());
+            return GetHashCode().Equals(obj?.GetHashCode());
         }
     }
 
@@ -87,7 +98,7 @@ namespace DevCycle.SDK.Server.Local.Api
                 
                 userEventBatches[user].Events.AddRange(entries.Value.Values.ToList());
             }
-
+            
             return userEventBatches;
         }
 
@@ -160,6 +171,7 @@ namespace DevCycle.SDK.Server.Local.Api
                 batchQueueMutex.WaitOne();
 
                 var userEventBatch = CombineUsersEventsToFlush();
+
                 if (userEventBatch.Count != 0)
                 {
                     batchQueue.Add(new BatchOfUserEventsBatch(userEventBatch.Values.ToList()));
@@ -176,7 +188,7 @@ namespace DevCycle.SDK.Server.Local.Api
                     OnFlushedEvents(eventArgs);
                 }
 
-                var eventCount = userEventBatch.Sum(u => userEventBatch.Values.Count);
+                var eventCount = userEventBatch.Sum(u => u.Value.Events.Count);
 
                 logger.LogInformation("DVC Flush {EventCount} Events, for {UserEventBatch} Users", eventCount, userEventBatch.Count);
                 

--- a/DevCycle.SDK.Server.Local/Api/UserAndFeatureVars.cs
+++ b/DevCycle.SDK.Server.Local/Api/UserAndFeatureVars.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using DevCycle.SDK.Server.Common.Model.Local;
+
+namespace DevCycle.SDK.Server.Local.Api;
+
+internal class UserAndFeatureVars
+{
+    public readonly DVCPopulatedUser User;
+    private readonly Dictionary<string, string> featureVars;
+
+    public UserAndFeatureVars(DVCPopulatedUser user, Dictionary<string, string> featureVars)
+    {
+        User = user;
+        this.featureVars = featureVars;
+    }
+
+    private int FeatureVarsHashCode()
+    {
+        var sum = 0;
+        foreach (var entry in featureVars)
+        {
+            sum += entry.Key.GetHashCode();
+            sum += entry.Value.GetHashCode();
+        }
+
+        return sum;
+    }
+
+    public override int GetHashCode()
+    {
+        return User.GetHashCode() + FeatureVarsHashCode();
+    }
+
+    public override bool Equals(object obj)
+    {
+        return GetHashCode().Equals(obj?.GetHashCode());
+    }
+}


### PR DESCRIPTION
- update aggregate event queue to group events by unique combinations of user data, feature vars, type and target
- update tests to verify resulting event batch payload
- adopt android approach of moving events in queue to outgoing batch payload queue, keep unsuccessful outgoing payloads in queue
- add mutex around methods for adding events to aggregate and regular queues
- make fields for DVCPopulatedUser and RequestEvent read-only