### PR TITLE
only retry requests that are retryable

### DIFF
--- a/DevCycle.SDK.Server.Common/Exception/DVCException.cs
+++ b/DevCycle.SDK.Server.Common/Exception/DVCException.cs
@@ -19,5 +19,10 @@ namespace DevCycle.SDK.Server.Common.Exception
         public HttpStatusCode HttpStatusCode { get; set; }
 
         public ErrorResponse ErrorResponse { get; set; }
+
+        public bool IsRetryable()
+        {
+            return (int)HttpStatusCode >= 500;
+        }
     }
 }


### PR DESCRIPTION
- drop events that failed due to 4xx error
- halt polling loop for config if 4xx error is encountered
- clean up error in case of 403 (config does not exist) to tell user to check their SDK token