### PR TITLE
Clone restClientOptions rather than mutating parameter

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
@@ -29,7 +29,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
                     ));
 
             DVCCloudClient api = (DVCCloudClient) new DVCCloudClientBuilder()
-                .SetRestClientOptions(new DvcRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
+                .SetRestClientOptions(new DVCRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
                 .SetOptions(options ?? new DVCCloudOptions())
                 .SetEnvironmentKey($"server-{Guid.NewGuid().ToString()}")
                 .SetLogger(new NullLoggerFactory())

--- a/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Cloud.Api;
+using DevCycle.SDK.Server.Common.API;
 using DevCycle.SDK.Server.Common.Model;
 using DevCycle.SDK.Server.Common.Model.Cloud;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -28,7 +29,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
                     ));
 
             DVCCloudClient api = (DVCCloudClient) new DVCCloudClientBuilder()
-                .SetRestClientOptions(new RestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
+                .SetRestClientOptions(new DvcRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
                 .SetOptions(options ?? new DVCCloudOptions())
                 .SetEnvironmentKey($"server-{Guid.NewGuid().ToString()}")
                 .SetLogger(new NullLoggerFactory())

--- a/DevCycle.SDK.Server.Cloud/Api/DVCApiClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCApiClient.cs
@@ -19,12 +19,12 @@ namespace DevCycle.SDK.Server.Cloud.Api
         {
         }
 
-        public DVCApiClient(string serverKey, DvcRestClientOptions restClientOptions = null)
+        public DVCApiClient(string serverKey, DVCRestClientOptions restClientOptions = null)
         {
             this.serverKey = serverKey;
 
             if (restClientOptions == null)
-                restClientOptions = new DvcRestClientOptions()
+                restClientOptions = new DVCRestClientOptions()
                 {
                     BaseUrl = new Uri(BaseURL)
                 };

--- a/DevCycle.SDK.Server.Cloud/Api/DVCApiClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCApiClient.cs
@@ -19,12 +19,12 @@ namespace DevCycle.SDK.Server.Cloud.Api
         {
         }
 
-        public DVCApiClient(string serverKey, RestClientOptions restClientOptions = null)
+        public DVCApiClient(string serverKey, DvcRestClientOptions restClientOptions = null)
         {
             this.serverKey = serverKey;
 
             if (restClientOptions == null)
-                restClientOptions = new RestClientOptions()
+                restClientOptions = new DvcRestClientOptions()
                 {
                     BaseUrl = new Uri(BaseURL)
                 };

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -27,7 +27,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
 
         private readonly DVCCloudOptions options;
 
-        internal DVCCloudClient(string serverKey, ILoggerFactory loggerFactory, IDVCOptions options=null, RestClientOptions restClientOptions = null)
+        internal DVCCloudClient(string serverKey, ILoggerFactory loggerFactory, IDVCOptions options=null, DvcRestClientOptions restClientOptions = null)
         {
             apiClient = new DVCApiClient(serverKey, restClientOptions);
             logger = loggerFactory.CreateLogger<DVCCloudClient>();

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -27,7 +27,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
 
         private readonly DVCCloudOptions options;
 
-        internal DVCCloudClient(string serverKey, ILoggerFactory loggerFactory, IDVCOptions options=null, DvcRestClientOptions restClientOptions = null)
+        internal DVCCloudClient(string serverKey, ILoggerFactory loggerFactory, IDVCOptions options=null, DVCRestClientOptions restClientOptions = null)
         {
             apiClient = new DVCApiClient(serverKey, restClientOptions);
             logger = loggerFactory.CreateLogger<DVCCloudClient>();

--- a/DevCycle.SDK.Server.Common/API/DVCRestClientOptions.cs
+++ b/DevCycle.SDK.Server.Common/API/DVCRestClientOptions.cs
@@ -1,0 +1,12 @@
+using RestSharp;
+
+namespace DevCycle.SDK.Server.Common.API
+{
+    public class DvcRestClientOptions : RestClientOptions
+    {
+        public DvcRestClientOptions Clone()
+        {
+            return (DvcRestClientOptions) MemberwiseClone();
+        }
+    }
+}

--- a/DevCycle.SDK.Server.Common/API/DVCRestClientOptions.cs
+++ b/DevCycle.SDK.Server.Common/API/DVCRestClientOptions.cs
@@ -2,11 +2,11 @@ using RestSharp;
 
 namespace DevCycle.SDK.Server.Common.API
 {
-    public class DvcRestClientOptions : RestClientOptions
+    public class DVCRestClientOptions : RestClientOptions
     {
-        public DvcRestClientOptions Clone()
+        public DVCRestClientOptions Clone()
         {
-            return (DvcRestClientOptions) MemberwiseClone();
+            return (DVCRestClientOptions) MemberwiseClone();
         }
     }
 }

--- a/DevCycle.SDK.Server.Common/Model/DVCClientBuilder.cs
+++ b/DevCycle.SDK.Server.Common/Model/DVCClientBuilder.cs
@@ -13,7 +13,7 @@ namespace DevCycle.SDK.Server.Common.Model
         protected IDVCOptions options;
         protected ILoggerFactory loggerFactory;
         protected EventHandler<DVCEventArgs> initialized;
-        protected DvcRestClientOptions restClientOptions;
+        protected DVCRestClientOptions restClientOptions;
         
         public IClientBuilder SetEnvironmentKey(string key)
         {
@@ -33,7 +33,7 @@ namespace DevCycle.SDK.Server.Common.Model
             return this;
         }
 
-        public IClientBuilder SetRestClientOptions(DvcRestClientOptions options)
+        public IClientBuilder SetRestClientOptions(DVCRestClientOptions options)
         {
             this.restClientOptions = options;
             return this;

--- a/DevCycle.SDK.Server.Common/Model/DVCClientBuilder.cs
+++ b/DevCycle.SDK.Server.Common/Model/DVCClientBuilder.cs
@@ -13,7 +13,7 @@ namespace DevCycle.SDK.Server.Common.Model
         protected IDVCOptions options;
         protected ILoggerFactory loggerFactory;
         protected EventHandler<DVCEventArgs> initialized;
-        protected RestClientOptions restClientOptions;
+        protected DvcRestClientOptions restClientOptions;
         
         public IClientBuilder SetEnvironmentKey(string key)
         {
@@ -33,7 +33,7 @@ namespace DevCycle.SDK.Server.Common.Model
             return this;
         }
 
-        public IClientBuilder SetRestClientOptions(RestClientOptions options)
+        public IClientBuilder SetRestClientOptions(DvcRestClientOptions options)
         {
             this.restClientOptions = options;
             return this;

--- a/DevCycle.SDK.Server.Common/Model/IClientBuilder.cs
+++ b/DevCycle.SDK.Server.Common/Model/IClientBuilder.cs
@@ -11,7 +11,7 @@ namespace DevCycle.SDK.Server.Common.Model
         IClientBuilder SetEnvironmentKey(string key);
         IClientBuilder SetOptions(IDVCOptions options);
         IClientBuilder SetLogger(ILoggerFactory loggerFactoryProvider);
-        IClientBuilder SetRestClientOptions(RestClientOptions options);
+        IClientBuilder SetRestClientOptions(DvcRestClientOptions options);
         IDVCClient Build();
     }
 }

--- a/DevCycle.SDK.Server.Common/Model/IClientBuilder.cs
+++ b/DevCycle.SDK.Server.Common/Model/IClientBuilder.cs
@@ -11,7 +11,7 @@ namespace DevCycle.SDK.Server.Common.Model
         IClientBuilder SetEnvironmentKey(string key);
         IClientBuilder SetOptions(IDVCOptions options);
         IClientBuilder SetLogger(ILoggerFactory loggerFactoryProvider);
-        IClientBuilder SetRestClientOptions(DvcRestClientOptions options);
+        IClientBuilder SetRestClientOptions(DVCRestClientOptions options);
         IDVCClient Build();
     }
 }

--- a/DevCycle.SDK.Server.Local.Example/Program.cs
+++ b/DevCycle.SDK.Server.Local.Example/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common.API;
 using DevCycle.SDK.Server.Common.Model;
 using DevCycle.SDK.Server.Common.Model.Local;
 using Microsoft.Extensions.Logging;

--- a/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
@@ -39,12 +39,12 @@ namespace DevCycle.SDK.Server.Local.MSTests
             localBucketing.StoreConfig(environmentKey, config);
             var configManager = new EnvironmentConfigManager(environmentKey, options ?? new DVCLocalOptions(),
                 new NullLoggerFactory(),
-                localBucketing, restClientOptions: new DvcRestClientOptions() {ConfigureMessageHandler = _ => mockHttp});
+                localBucketing, restClientOptions: new DVCRestClientOptions() {ConfigureMessageHandler = _ => mockHttp});
             configManager.Initialized = true;
             DVCLocalClient api = (DVCLocalClient) new DVCLocalClientBuilder()
                 .SetLocalBucketing(localBucketing)
                 .SetConfigManager(configManager)
-                .SetRestClientOptions(new DvcRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
+                .SetRestClientOptions(new DVCRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
                 .SetOptions(options ?? new DVCLocalOptions())
                 .SetEnvironmentKey(environmentKey)
                 .SetLogger(loggerFactory)

--- a/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Local.Api;
 using DevCycle.SDK.Server.Local.ConfigManager;
+using DevCycle.SDK.Server.Common.API;
 using DevCycle.SDK.Server.Common.Model;
 using DevCycle.SDK.Server.Common.Model.Local;
 using Microsoft.Extensions.Logging;
@@ -38,12 +39,12 @@ namespace DevCycle.SDK.Server.Local.MSTests
             localBucketing.StoreConfig(environmentKey, config);
             var configManager = new EnvironmentConfigManager(environmentKey, options ?? new DVCLocalOptions(),
                 new NullLoggerFactory(),
-                localBucketing, restClientOptions: new RestClientOptions() {ConfigureMessageHandler = _ => mockHttp});
+                localBucketing, restClientOptions: new DvcRestClientOptions() {ConfigureMessageHandler = _ => mockHttp});
             configManager.Initialized = true;
             DVCLocalClient api = (DVCLocalClient) new DVCLocalClientBuilder()
                 .SetLocalBucketing(localBucketing)
                 .SetConfigManager(configManager)
-                .SetRestClientOptions(new RestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
+                .SetRestClientOptions(new DvcRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
                 .SetOptions(options ?? new DVCLocalOptions())
                 .SetEnvironmentKey(environmentKey)
                 .SetLogger(loggerFactory)

--- a/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Local.Api;
 using DevCycle.SDK.Server.Local.ConfigManager;
+using DevCycle.SDK.Server.Common.API;
 using DevCycle.SDK.Server.Common.Model;
 using DevCycle.SDK.Server.Common.Model.Local;
 using Microsoft.Extensions.Logging;
@@ -38,7 +39,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
             var environmentKey = $"server-{Guid.NewGuid()}";
             var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             var cfgManager = new EnvironmentConfigManager(environmentKey, new DVCLocalOptions(),
-                loggerFactory, new LocalBucketing(), restClientOptions: new RestClientOptions()
+                loggerFactory, new LocalBucketing(), restClientOptions: new DvcRestClientOptions()
                     {ConfigureMessageHandler = _ => mockHttp},
                 initializedHandler: isError ? DidNotInitializeSubscriber : DidInitializeSubscriber);
 

--- a/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
@@ -39,7 +39,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
             var environmentKey = $"server-{Guid.NewGuid()}";
             var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             var cfgManager = new EnvironmentConfigManager(environmentKey, new DVCLocalOptions(),
-                loggerFactory, new LocalBucketing(), restClientOptions: new DvcRestClientOptions()
+                loggerFactory, new LocalBucketing(), restClientOptions: new DVCRestClientOptions()
                     {ConfigureMessageHandler = _ => mockHttp},
                 initializedHandler: isError ? DidNotInitializeSubscriber : DidInitializeSubscriber);
 

--- a/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
@@ -47,7 +47,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
             localBucketing.SetPlatformData(JsonConvert.SerializeObject(new PlatformData()));
 
             var eventQueue = new EventQueue(environmentKey, localOptions, loggerFactory,
-                localBucketing, new DvcRestClientOptions() { ConfigureMessageHandler = _ => mockHttp });
+                localBucketing, new DVCRestClientOptions() { ConfigureMessageHandler = _ => mockHttp });
             return new Tuple<EventQueue, MockHttpMessageHandler, MockedRequest>(eventQueue, mockHttp, req);
         }
 

--- a/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EventQueueTest.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common.API;
 using DevCycle.SDK.Server.Common.Model;
 using DevCycle.SDK.Server.Common.Model.Local;
 using Microsoft.Extensions.Logging;
@@ -46,7 +47,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
             localBucketing.SetPlatformData(JsonConvert.SerializeObject(new PlatformData()));
 
             var eventQueue = new EventQueue(environmentKey, localOptions, loggerFactory,
-                localBucketing, new RestClientOptions() { ConfigureMessageHandler = _ => mockHttp });
+                localBucketing, new DvcRestClientOptions() { ConfigureMessageHandler = _ => mockHttp });
             return new Tuple<EventQueue, MockHttpMessageHandler, MockedRequest>(eventQueue, mockHttp, req);
         }
 

--- a/DevCycle.SDK.Server.Local/Api/DVCEventsApiClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCEventsApiClient.cs
@@ -21,17 +21,15 @@ namespace DevCycle.SDK.Server.Local.Api
         {
         }
 
-        public DVCEventsApiClient(string environmentKey, DVCLocalOptions options = null, RestClientOptions restClientOptions = null)
+        public DVCEventsApiClient(string environmentKey, DVCLocalOptions options = null, DvcRestClientOptions restClientOptions = null)
         {
             options ??= new DVCLocalOptions();
-            restClientOptions ??= new RestClientOptions()
-            {
-                BaseUrl = new Uri(options.EventsApiUri)
-            };
+            DVCRestClientOptions clientOptions = restClientOptions?.Clone() ?? new DVCRestClientOptions();
+            if (string.IsNullOrEmpty(clientOptions.BaseUrl?.ToString()))
+                clientOptions.BaseUrl = new Uri(options.EventsApiUri);
             options.EventsApiCustomHeaders ??= new Dictionary<string, string>();
-            if (string.IsNullOrEmpty(restClientOptions.BaseUrl?.ToString()))
-                restClientOptions.BaseUrl = new Uri(options.EventsApiUri);
-            restClient = new RestClient(restClientOptions);
+ 
+            restClient = new RestClient(clientOptions);
             restClient.AddDefaultHeaders(options.EventsApiCustomHeaders);
             SdkKey = environmentKey;
             sdkOptions = options;

--- a/DevCycle.SDK.Server.Local/Api/DVCEventsApiClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCEventsApiClient.cs
@@ -21,7 +21,7 @@ namespace DevCycle.SDK.Server.Local.Api
         {
         }
 
-        public DVCEventsApiClient(string environmentKey, DVCLocalOptions options = null, DvcRestClientOptions restClientOptions = null)
+        public DVCEventsApiClient(string environmentKey, DVCLocalOptions options = null, DVCRestClientOptions restClientOptions = null)
         {
             options ??= new DVCLocalOptions();
             DVCRestClientOptions clientOptions = restClientOptions?.Clone() ?? new DVCRestClientOptions();

--- a/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
@@ -70,7 +70,7 @@ namespace DevCycle.SDK.Server.Local.Api
 
         internal DVCLocalClient(string environmentKey, DVCLocalOptions dvcLocalOptions, ILoggerFactory loggerFactory,
             EnvironmentConfigManager configManager, ILocalBucketing localBucketing,
-            RestClientOptions restClientOptions = null)
+            DvcRestClientOptions restClientOptions = null)
         {
             this.environmentKey = environmentKey;
             this.configManager = configManager;

--- a/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
@@ -70,7 +70,7 @@ namespace DevCycle.SDK.Server.Local.Api
 
         internal DVCLocalClient(string environmentKey, DVCLocalOptions dvcLocalOptions, ILoggerFactory loggerFactory,
             EnvironmentConfigManager configManager, ILocalBucketing localBucketing,
-            DvcRestClientOptions restClientOptions = null)
+            DVCRestClientOptions restClientOptions = null)
         {
             this.environmentKey = environmentKey;
             this.configManager = configManager;

--- a/DevCycle.SDK.Server.Local/Api/EventQueue.cs
+++ b/DevCycle.SDK.Server.Local/Api/EventQueue.cs
@@ -29,7 +29,7 @@ namespace DevCycle.SDK.Server.Local.Api
         private event EventHandler<DVCEventArgs> FlushedEvents;
         
         public EventQueue(string environmentKey, DVCLocalOptions localOptions, ILoggerFactory loggerFactory,
-            ILocalBucketing localBucketing, DvcRestClientOptions restClientOptions = null)
+            ILocalBucketing localBucketing, DVCRestClientOptions restClientOptions = null)
         {
             dvcEventsApiClient = new DVCEventsApiClient(environmentKey, localOptions, restClientOptions);
             this.environmentKey = environmentKey;

--- a/DevCycle.SDK.Server.Local/Api/EventQueue.cs
+++ b/DevCycle.SDK.Server.Local/Api/EventQueue.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using DevCycle.SDK.Server.Common.API;
 using DevCycle.SDK.Server.Common.Exception;
 using DevCycle.SDK.Server.Common.Model;
 using DevCycle.SDK.Server.Common.Model.Local;
@@ -28,7 +29,7 @@ namespace DevCycle.SDK.Server.Local.Api
         private event EventHandler<DVCEventArgs> FlushedEvents;
         
         public EventQueue(string environmentKey, DVCLocalOptions localOptions, ILoggerFactory loggerFactory,
-            ILocalBucketing localBucketing, RestClientOptions restClientOptions = null)
+            ILocalBucketing localBucketing, DvcRestClientOptions restClientOptions = null)
         {
             dvcEventsApiClient = new DVCEventsApiClient(environmentKey, localOptions, restClientOptions);
             this.environmentKey = environmentKey;

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -42,7 +42,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         public EnvironmentConfigManager(string environmentKey, DVCLocalOptions dvcLocalOptions,
             ILoggerFactory loggerFactory,
             ILocalBucketing localBucketing, EventHandler<DVCEventArgs> initializedHandler = null,
-            DvcRestClientOptions restClientOptions = null)
+            DVCRestClientOptions restClientOptions = null)
         {
             localOptions = dvcLocalOptions;
             this.environmentKey = environmentKey;
@@ -55,7 +55,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
                 : dvcLocalOptions.ConfigPollingTimeoutMs;
             dvcLocalOptions.CdnCustomHeaders ??= new Dictionary<string, string>();
 
-            DvcRestClientOptions clientOptions = restClientOptions?.Clone() ?? new DvcRestClientOptions();
+            DVCRestClientOptions clientOptions = restClientOptions?.Clone() ?? new DVCRestClientOptions();
             // Explicitly override the base URL to use the one in local bucketing options. This allows the normal 
             // rest client options to override the Events api endpoint url; while sharing certificate and other information.
             clientOptions.BaseUrl = new Uri(dvcLocalOptions.CdnUri);


### PR DESCRIPTION
The same instance of RestClientOptions is passed to the events API client and the cdn API client, both mutate the base url, which was causing the events requests to be sent to the cdn url.

Create DvcRestClientOptions class that extends RestClientOptions and adds a Clone method. This allows us to clone the rest client options before mutating.