### PR TITLE
fix dotnet builder types

### DIFF
--- a/DevCycle.SDK.Server.Cloud.Example/Program.cs
+++ b/DevCycle.SDK.Server.Cloud.Example/Program.cs
@@ -14,7 +14,7 @@ namespace Example
         {
             var SDK_ENV_VAR = Environment.GetEnvironmentVariable("DEVCYCLE_SDK_TOKEN");
 
-            DVCCloudClient api = new DVCCloudClientBuilder().SetEnvironmentKey(SDK_ENV_VAR).SetLogger(new NullLoggerFactory()).Build();
+            DVCCloudClient api = (DVCCloudClient) new DVCCloudClientBuilder().SetEnvironmentKey(SDK_ENV_VAR).SetLogger(new NullLoggerFactory()).Build();
             
             var user = new User("user_id");
 

--- a/DevCycle.SDK.Server.Cloud.Example/Program.cs
+++ b/DevCycle.SDK.Server.Cloud.Example/Program.cs
@@ -14,7 +14,7 @@ namespace Example
         {
             var SDK_ENV_VAR = Environment.GetEnvironmentVariable("DEVCYCLE_SDK_TOKEN");
 
-            DVCCloudClient api = (DVCCloudClient) new DVCCloudClientBuilder().SetEnvironmentKey(SDK_ENV_VAR).SetLogger(new NullLoggerFactory()).Build();
+            DVCCloudClient api = new DVCCloudClientBuilder().SetEnvironmentKey(SDK_ENV_VAR).SetLogger(new NullLoggerFactory()).Build();
             
             var user = new User("user_id");
 

--- a/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
@@ -28,7 +28,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
                         bodyResponse
                     ));
 
-            DVCCloudClient api = (DVCCloudClient) new DVCCloudClientBuilder()
+            DVCCloudClient api = new DVCCloudClientBuilder()
                 .SetRestClientOptions(new DVCRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
                 .SetOptions(options ?? new DVCCloudOptions())
                 .SetEnvironmentKey($"server-{Guid.NewGuid().ToString()}")
@@ -48,8 +48,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
                 return;
             }
 
-            DVCCloudClient api = (DVCCloudClient)
-                new DVCCloudClientBuilder()
+            DVCCloudClient api = new DVCCloudClientBuilder()
                     .SetEnvironmentKey(Environment.GetEnvironmentVariable("DEVCYCLE_SDK_KEY"))
                     .SetLogger(new NullLoggerFactory())
                     .Build();

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -13,9 +13,11 @@ using RestSharp;
 namespace DevCycle.SDK.Server.Cloud.Api
 {
 
-    public class DVCCloudClientBuilder : DVCClientBuilder
+    public class DVCCloudClientBuilder : DVCClientBuilder<DVCCloudClient, DVCCloudOptions, DVCCloudClientBuilder>
     {
-        public override IDVCClient Build()
+        protected override DVCCloudClientBuilder BuilderInstance => this;
+
+        public override DVCCloudClient Build()
         {
             return new DVCCloudClient(environmentKey, loggerFactory, options, restClientOptions);
         }

--- a/DevCycle.SDK.Server.Common/Model/DVCClientBuilder.cs
+++ b/DevCycle.SDK.Server.Common/Model/DVCClientBuilder.cs
@@ -7,38 +7,47 @@ using RestSharp;
 namespace DevCycle.SDK.Server.Common.Model
 {
 
-    public abstract class DVCClientBuilder : IClientBuilder
+    public abstract class DVCClientBuilder<ClientType, OptionsType, BuilderType> : IClientBuilder<
+        ClientType, 
+        OptionsType,
+        BuilderType
+    >
+        where ClientType : IDVCClient
+        where OptionsType : IDVCOptions
+        where BuilderType : DVCClientBuilder<ClientType, OptionsType, BuilderType>
     {
         protected string environmentKey;
-        protected IDVCOptions options;
+        protected OptionsType options;
         protected ILoggerFactory loggerFactory;
         protected EventHandler<DVCEventArgs> initialized;
         protected DVCRestClientOptions restClientOptions;
+
+        protected abstract BuilderType BuilderInstance { get; }
         
-        public IClientBuilder SetEnvironmentKey(string key)
+        public BuilderType SetEnvironmentKey(string key)
         {
             environmentKey = key;
-            return this;
+            return BuilderInstance;
         }
 
-        public IClientBuilder SetOptions(IDVCOptions dvcOptions)
+        public BuilderType SetOptions(OptionsType dvcOptions)
         {
             options = dvcOptions;
-            return this;
+            return BuilderInstance;
         }
 
-        public IClientBuilder SetLogger(ILoggerFactory loggerFactoryProvider)
+        public BuilderType SetLogger(ILoggerFactory loggerFactoryProvider)
         {
             loggerFactory = loggerFactoryProvider;
-            return this;
+            return BuilderInstance;
         }
 
-        public IClientBuilder SetRestClientOptions(DVCRestClientOptions options)
+        public BuilderType SetRestClientOptions(DVCRestClientOptions options)
         {
             this.restClientOptions = options;
-            return this;
+            return BuilderInstance;
         }
 
-        public abstract IDVCClient Build();
+        public abstract ClientType Build();
     }
 }

--- a/DevCycle.SDK.Server.Common/Model/IClientBuilder.cs
+++ b/DevCycle.SDK.Server.Common/Model/IClientBuilder.cs
@@ -6,12 +6,16 @@ using RestSharp;
 
 namespace DevCycle.SDK.Server.Common.Model
 {
-    public interface IClientBuilder
+    public interface IClientBuilder<ClientType, OptionsType, BuilderType>
+        where ClientType : IDVCClient
+        where OptionsType: IDVCOptions
+        where BuilderType: IClientBuilder<ClientType, OptionsType, BuilderType>
     {
-        IClientBuilder SetEnvironmentKey(string key);
-        IClientBuilder SetOptions(IDVCOptions options);
-        IClientBuilder SetLogger(ILoggerFactory loggerFactoryProvider);
-        IClientBuilder SetRestClientOptions(DVCRestClientOptions options);
-        IDVCClient Build();
+        BuilderType SetEnvironmentKey(string key);
+        BuilderType SetOptions(OptionsType options);
+        BuilderType SetLogger(ILoggerFactory loggerFactoryProvider);
+        BuilderType SetRestClientOptions(DVCRestClientOptions options);
+
+        ClientType Build();
     }
 }

--- a/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
@@ -41,7 +41,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
                 new NullLoggerFactory(),
                 localBucketing, restClientOptions: new DVCRestClientOptions() {ConfigureMessageHandler = _ => mockHttp});
             configManager.Initialized = true;
-            DVCLocalClient api = (DVCLocalClient) new DVCLocalClientBuilder()
+            DVCLocalClient api = new DVCLocalClientBuilder()
                 .SetLocalBucketing(localBucketing)
                 .SetConfigManager(configManager)
                 .SetRestClientOptions(new DVCRestClientOptions() {ConfigureMessageHandler = _ => mockHttp})
@@ -84,7 +84,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
                 return;
             }
 
-            var api = (DVCLocalClient) new DVCLocalClientBuilder()
+            var api = new DVCLocalClientBuilder()
                 .SetInitializedSubscriber(((sender, args) => { Console.WriteLine($"Success? : {args.Success}"); }))
                 .SetEnvironmentKey(sdkKey)
                 .Build();

--- a/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
@@ -11,12 +11,12 @@ using RestSharp;
 
 namespace DevCycle.SDK.Server.Local.Api
 {
-    public class DVCLocalClientBuilder : DVCClientBuilder
+    public class DVCLocalClientBuilder : DVCClientBuilder<DVCLocalClient, DVCLocalOptions, DVCLocalClientBuilder>
     {
         private EnvironmentConfigManager configManager;
         private ILocalBucketing localBucketing;
-        private DVCLocalOptions localOptions;
-
+        
+        protected override DVCLocalClientBuilder BuilderInstance => this;
 
         public DVCLocalClientBuilder SetConfigManager(EnvironmentConfigManager environmentConfigManager)
         {
@@ -36,25 +36,18 @@ namespace DevCycle.SDK.Server.Local.Api
             return this;
         }
 
-        public new DVCLocalClientBuilder SetOptions(IDVCOptions options)
-        {
-            this.options = options;
-            localOptions = (DVCLocalOptions) options;
-            return this;
-        }
-
-        public override IDVCClient Build()
+        public override DVCLocalClient Build()
         {
             localBucketing ??= new LocalBucketing();
 
-            localOptions ??= new DVCLocalOptions();
+            options ??= new DVCLocalOptions();
 
             loggerFactory ??= LoggerFactory.Create(builder => builder.AddConsole());
 
-            configManager ??= new EnvironmentConfigManager(environmentKey, localOptions, loggerFactory, localBucketing,
+            configManager ??= new EnvironmentConfigManager(environmentKey, options, loggerFactory, localBucketing,
                 initialized, restClientOptions);
 
-            return new DVCLocalClient(environmentKey, localOptions, loggerFactory, configManager, localBucketing,
+            return new DVCLocalClient(environmentKey, options, loggerFactory, configManager, localBucketing,
                 restClientOptions);
         }
     }


### PR DESCRIPTION
Use generics to return the correct builder type from each implementation of the abstract builder class.

Also return the correct kind of client from the `Build` calls.

This allows you to get the correct types without casting:

```csharp
DVCLocalClient client = new DVCLocalClientBuilder()
    .SetEnvironmentKey(clientBody.sdkKey)
    .SetOptions(clientBody.options)
    .SetInitializedSubscriber((o, e) => {}})
    .SetLogger(new LoggerFactory())
    .Build();
```