### PR TITLE
fix variable class types for cloud client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ riderModule.iml
 *.suo
 *.user
 *.sln.docstates
+global.json
 
 # Build results
 

--- a/DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
+++ b/DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevCycle.SDK.Server.Cloud" Version="1.3.5" />
+    <PackageReference Include="DevCycle.SDK.Server.Cloud" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta2" />
     <PackageReference Include="RestSharp" Version="108.0.2-alpha.0.6" />
   </ItemGroup>

--- a/DevCycle.SDK.Server.Cloud.Example/Program.cs
+++ b/DevCycle.SDK.Server.Cloud.Example/Program.cs
@@ -14,7 +14,7 @@ namespace Example
         {
             var SDK_ENV_VAR = Environment.GetEnvironmentVariable("DEVCYCLE_SDK_TOKEN");
 
-            DVCCloudClient api = (DVCCloudClient) new DVCCloudClientBuilder().SetEnvironmentKey(SDK_ENV_VAR).SetLogger(new NullLoggerFactory()).Build();
+            DVCCloudClient api = new DVCCloudClientBuilder().SetEnvironmentKey(SDK_ENV_VAR).SetLogger(new NullLoggerFactory()).Build();
             
             var user = new User("user_id");
 

--- a/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DVCTest.cs
@@ -90,7 +90,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
             AssertUserDefaultsCorrect(user);
 
             Assert.IsNotNull(result);
-            Assert.IsFalse((bool) ((Variable) result).Value);
+            Assert.IsFalse(result.Value);
         }
 
         [TestMethod]

--- a/DevCycle.SDK.Server.Cloud.MSTests/TestResponse.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/TestResponse.cs
@@ -19,18 +19,18 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
             };
         }
 
-        public static Variable GetVariableByKeyAsync()
+        public static Variable<bool> GetVariableByKeyAsync()
         {
-            return new Variable(Guid.NewGuid().ToString(), "test-false", TypeEnum.Boolean, false);
+            return new Variable<bool>(Guid.NewGuid().ToString(), "test-false", TypeEnum.Boolean, false);
         }
 
-        public static Dictionary<string, Variable> GetVariablesAsync()
+        public static Dictionary<string, Variable<bool>> GetVariablesAsync()
         {
-            return new Dictionary<string, Variable>
+            return new Dictionary<string, Variable<bool>>
             {
                 {
                     "test-false",
-                    new Variable(Guid.NewGuid().ToString(), "test-false", TypeEnum.Boolean, false)
+                    new Variable<bool>(Guid.NewGuid().ToString(), "test-false", TypeEnum.Boolean, false)
                 }
             };
         }

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -59,7 +59,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             return await GetResponseAsync<Dictionary<string, Feature>>(user, urlFragment, queryParams);
         }
 
-        public async Task<IVariable> VariableAsync<T>(User user, string key, T defaultValue)
+        public async Task<Variable<T>> VariableAsync<T>(User user, string key, T defaultValue)
         {
             ValidateUser(user);
 
@@ -81,21 +81,21 @@ namespace DevCycle.SDK.Server.Cloud.Api
             var queryParams = new Dictionary<string, string>();
             if (options.EnableEdgeDB) queryParams.Add("enableEdgeDB", "true");
 
-            Variable variable;
+            Variable<T> variable;
 
             try
             {
-                variable = await GetResponseAsync<Variable>(user, urlFragment, queryParams);
+                variable = await GetResponseAsync<Variable<T>>(user, urlFragment, queryParams);
             }
             catch (DVCException e)
             {
-                variable = new Variable(lowerKey, (object) defaultValue, e.Message);
+                variable = new Variable<T>(lowerKey, defaultValue, e.Message);
             }
 
             return variable;
         }
 
-        public async Task<Dictionary<string, Variable>> AllVariablesAsync(User user)
+        public async Task<Dictionary<string, Variable<object>>> AllVariablesAsync(User user)
         {
             ValidateUser(user);
 
@@ -106,7 +106,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             if (options.EnableEdgeDB) queryParams.Add("enableEdgeDB", "true");
 
 
-            return await GetResponseAsync<Dictionary<string, Variable>>(user, urlFragment, queryParams);
+            return await GetResponseAsync<Dictionary<string, Variable<object>>>(user, urlFragment, queryParams);
         }
 
         public async Task<DVCResponse> TrackAsync(User user, Event userEvent)

--- a/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
+++ b/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
@@ -65,7 +65,7 @@ namespace DevCycle.SDK.Server.Common.API
                         return JsonConvert.DeserializeObject<T>(response.Content);
                 }
 
-                var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.StatusDescription ?? string.Empty);
+                var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content ?? string.Empty);
                 throw new DVCException(response.StatusCode, errorResponse);
             }
             catch (System.Exception e)

--- a/DevCycle.SDK.Server.Common/Model/Cloud/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Cloud/Variable.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace DevCycle.SDK.Server.Common.Model.Cloud
 {
  [DataContract]
-    public class Variable : IEquatable<Variable>, IVariable
+    public class Variable<T> : IEquatable<Variable<T>>, IVariable
     {
         /// <summary>
         /// Variable type
@@ -22,7 +22,7 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
         /// <param name="key">Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id. (required).</param>
         /// <param name="type">Variable type (required).</param>
         /// <param name="value">Variable value can be a string, number, boolean, or JSON (required).</param>
-        public Variable(string id = default, string key = default, TypeEnum type = default, Object value = default)
+        public Variable(string id = default, string key = default, TypeEnum type = default, T value = default)
         {
             // to ensure "id" is required (not null)
             if (id == null)
@@ -52,7 +52,7 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
             IsDefaulted = false;
         }
 
-        public Variable(string key, Object defaultValue, string evalReason)
+        public Variable(string key, T defaultValue, string evalReason)
         {
             Key = key;
             Value = defaultValue;
@@ -85,7 +85,7 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
         /// </summary>
         /// <value>Variable value can be a string, number, boolean, or JSON</value>
         [DataMember(Name="value", EmitDefaultValue=false)]
-        public Object Value { get; set; }
+        public T Value { get; set; }
         public bool IsDefaulted { get; set; }
         
         public string EvalReason { get; set; }
@@ -122,7 +122,7 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
         /// <returns>Boolean</returns>
         public override bool Equals(object input)
         {
-            return Equals(input as Variable);
+            return Equals(input as Variable<T>);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
         /// </summary>
         /// <param name="input">Instance of Variable to be compared</param>
         /// <returns>Boolean</returns>
-        public bool Equals(Variable input)
+        public bool Equals(Variable<T> input)
         {
             if (input == null)
                 return false;
@@ -151,7 +151,6 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
                     Type.Equals(input.Type)
                 ) && 
                 (
-                    Value == input.Value ||
                     (Value != null &&
                     Value.Equals(input.Value))
                 );

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <RootNamespace>Example</RootNamespace>
   </PropertyGroup>
@@ -13,8 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.4.0" />
-    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.0.0" />
+    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta2" />
     <PackageReference Include="RestSharp" Version="108.0.2-alpha.0.6" />
   </ItemGroup>


### PR DESCRIPTION
- fix type returned by cloud client to be `Variable`, not `IVariable`
- add generic to represent variable value type inferrable from default value