### PR TITLE
use default value for variable if server type is wrong 

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/TestResponse.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/TestResponse.cs
@@ -21,7 +21,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
 
         public static Variable<bool> GetVariableByKeyAsync()
         {
-            return new Variable<bool>("test-false", TypeEnum.Boolean, false, false);
+            return new Variable<bool>("test-false", false, false);
         }
 
         public static Dictionary<string, Variable<bool>> GetVariablesAsync()
@@ -30,7 +30,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
             {
                 {
                     "test-false",
-                    new Variable<bool>("test-false", TypeEnum.Boolean, false, false)
+                    new Variable<bool>("test-false", false, false)
                 }
             };
         }

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -85,13 +85,21 @@ namespace DevCycle.SDK.Server.Cloud.Api
 
             try
             {
-                variable = await GetResponseAsync<Variable<T>>(user, urlFragment, queryParams);
-                variable.DefaultValue = defaultValue;
-                variable.IsDefaulted = false;
+                var variableResponse = await GetResponseAsync<Variable<object>>(user, urlFragment, queryParams);
+                variableResponse.DefaultValue = defaultValue;
+                variableResponse.IsDefaulted = false;
+                variable = variableResponse as Variable<T>;
+                if (variable == null)
+                {
+                    variable = new Variable<T>(lowerKey, defaultValue, defaultValue);
+                    variable.IsDefaulted = true;
+                    Console.WriteLine($"Type mismatch for variable {key}. Expected asdas, got {variable.Type}");
+                    logger.LogWarning($"Type mismatch for variable {key}. Expected asdas, got {variable.Type}");
+                }
             }
             catch (DVCException e)
             {
-                variable = new Variable<T>(lowerKey, defaultValue, e.Message);
+                variable = new Variable<T>(lowerKey, defaultValue);
             }
 
             return variable;

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -93,8 +93,8 @@ namespace DevCycle.SDK.Server.Cloud.Api
                 {
                     variable = new Variable<T>(lowerKey, defaultValue, defaultValue);
                     variable.IsDefaulted = true;
-                    Console.WriteLine($"Type mismatch for variable {key}. Expected asdas, got {variable.Type}");
-                    logger.LogWarning($"Type mismatch for variable {key}. Expected asdas, got {variable.Type}");
+                    logger.LogWarning($"Type mismatch for variable {key}. " +
+                                      $"Expected {Common.Model.Local.Variable<T>.DetermineType(defaultValue)}, got {variable.Type}");
                 }
             }
             catch (DVCException e)

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -98,15 +98,17 @@ namespace DevCycle.SDK.Server.Cloud.Api
                 }
                 catch (InvalidCastException e)
                 {
-                    variable = new Variable<T>(lowerKey, defaultValue, defaultValue);
-                    variable.IsDefaulted = true;
+                    variable = new Variable<T>(lowerKey, defaultValue);
                     logger.LogWarning($"Type mismatch for variable {key}. " +
                                       $"Expected {type}, got {variableResponse.Type}");
                 }
             }
             catch (DVCException e)
             {
-                logger.LogError(e, "Failed to retrieve variable value, using default.");
+                if (e.IsRetryable())
+                {
+                    logger.LogError(e, "Failed to retrieve variable value, using default.");
+                }
                 variable = new Variable<T>(lowerKey, defaultValue);
             }
 

--- a/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
+++ b/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
@@ -58,7 +58,6 @@ namespace DevCycle.SDK.Server.Common.API
             try
             {
                 response = await GetApiClient().SendRequestAsync(body, urlFragment, queryParams);
-                Console.WriteLine(response.Content);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     if (response.Content != null)

--- a/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
+++ b/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
@@ -58,6 +58,7 @@ namespace DevCycle.SDK.Server.Common.API
             try
             {
                 response = await GetApiClient().SendRequestAsync(body, urlFragment, queryParams);
+                Console.WriteLine(response.Content);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     if (response.Content != null)

--- a/DevCycle.SDK.Server.Common/Model/Cloud/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Cloud/Variable.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Newtonsoft.Json;
 
 [assembly: InternalsVisibleTo("DevCycle.SDK.Server.Cloud.MSTests")]
+[assembly: InternalsVisibleTo( "DevCycle.SDK.Server.Cloud")]
 
 namespace DevCycle.SDK.Server.Common.Model.Cloud
 {
@@ -24,7 +25,7 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
         /// <param name="key">Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id. (required).</param>
         /// <param name="type">Variable type (required).</param>
         /// <param name="value">Variable value can be a string, number, boolean, or JSON (required).</param>
-        internal Variable(string key = default, TypeEnum type = default, T value = default, T defaultValue = default)
+        internal Variable(string key = default, T value = default, T defaultValue = default)
         {
             // to ensure "key" is required (not null)
             if (key == null)
@@ -34,7 +35,7 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
 
             Key = key;
 
-            Type = type;
+            Type = Local.Variable<T>.DetermineType(defaultValue);
 
             // to ensure "value" is required (not null)
             if (value == null)
@@ -54,12 +55,12 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
             IsDefaulted = false;
         }
 
-        public Variable(string key, T defaultValue, string evalReason)
+        public Variable(string key, T defaultValue)
         {
             Key = key;
             Value = defaultValue;
             DefaultValue = defaultValue;
-            EvalReason = evalReason;
+            Type = Local.Variable<T>.DetermineType(defaultValue);
             IsDefaulted = true;
         }
 

--- a/DevCycle.SDK.Server.Common/Model/Cloud/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Cloud/Variable.cs
@@ -14,10 +14,33 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
     public class Variable<T> : IEquatable<Variable<T>>, IVariable
     {
         /// <summary>
+        /// Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.
+        /// </summary>
+        /// <value>Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.</value>
+        [DataMember(Name="key")]
+        public string Key { get; set; }
+
+
+        /// <summary>
+        /// Variable value can be a string, number, boolean, or JSON
+        /// </summary>
+        /// <value>Variable value can be a string, number, boolean, or JSON</value>
+        [DataMember(Name="value")]
+        public T Value { get; set; }
+        
+        [DataMember(Name="defaultValue")]
+        public T DefaultValue { get; set; }
+        
+        [DataMember(Name="isDefaulted")]
+        public bool IsDefaulted { get; set; }
+        
+        public string EvalReason { get; set; }
+        
+        /// <summary>
         /// Variable type
         /// </summary>
         /// <value>Variable type</value>
-        [DataMember(Name="type", EmitDefaultValue=false)]
+        [DataMember(Name="type")]
         public TypeEnum Type { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="Variable" /> class.
@@ -64,33 +87,11 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
             IsDefaulted = true;
         }
 
+        [JsonConstructor]
         Variable()
         {
 
         }
-
-        /// <summary>
-        /// Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.
-        /// </summary>
-        /// <value>Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.</value>
-        [DataMember(Name="key")]
-        public string Key { get; set; }
-
-
-        /// <summary>
-        /// Variable value can be a string, number, boolean, or JSON
-        /// </summary>
-        /// <value>Variable value can be a string, number, boolean, or JSON</value>
-        [DataMember(Name="value")]
-        public T Value { get; set; }
-        
-        [DataMember(Name="defaultValue")]
-        public T DefaultValue { get; set; }
-        
-        [DataMember(Name="isDefaulted")]
-        public bool IsDefaulted { get; set; }
-        
-        public string EvalReason { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -168,6 +169,20 @@ namespace DevCycle.SDK.Server.Common.Model.Cloud
                     hashCode = hashCode * 59 + Value.GetHashCode();
                 return hashCode;
             }
+        }
+    }
+    
+    public static class VariableHelper
+    {
+        public static Variable<T> Convert<T>(this Variable<object> variable)
+        {
+            var defaultValue = variable.DefaultValue;
+            var value = variable.Value;
+
+            return new Variable<T>(variable.Key, (T) value, (T) defaultValue)
+            {
+                IsDefaulted = variable.IsDefaulted,
+            };
         }
     }
 }

--- a/DevCycle.SDK.Server.Common/Model/IVariable.cs
+++ b/DevCycle.SDK.Server.Common/Model/IVariable.cs
@@ -38,7 +38,7 @@ namespace DevCycle.SDK.Server.Common.Model
         /// Variable type
         /// </summary>
         /// <value>Variable type</value>
-        [DataMember(Name = "type", EmitDefaultValue = false)]
+        [DataMember(Name = "type")]
         public TypeEnum Type { get; set; }
 
         public string Key { get; set; }

--- a/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
@@ -70,6 +70,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             {
                 returnVariable.Key = variable.Key;
                 returnVariable.Value = variable.Value;
+                returnVariable.DefaultValue = defaultValue;
                 returnVariable.Type = variable.Type;
                 returnVariable.EvalReason = variable.EvalReason;
                 returnVariable.IsDefaulted = false;
@@ -113,34 +114,45 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         public bool IsDefaulted { get; set; }
         public string EvalReason { get; set; }
 
-        public static TypeEnum DetermineType(T variableType)
+        public static TypeEnum DetermineType(T variableValue)
         {
             TypeEnum typeEnum;
-            var type = variableType.GetType().GetExtendedType();
+    
+            try
+            {
+                var baseType = variableValue.GetType();
+                var type = baseType.GetExtendedType();
 
-            if (type == typeof(string))
-            {
-                typeEnum = TypeEnum.String;
-            }
-            else if (type.IsNumericType)
-            {
-                typeEnum = TypeEnum.Number;
-            }
-            else if (type == typeof(bool))
-            {
-                typeEnum = TypeEnum.Boolean;
-            }
-            else if (variableType.GetType().IsSubclassOf(typeof(JContainer)))
-            {
-                typeEnum = TypeEnum.JSON;
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"{type} is not a valid type. Must be String / Number / Boolean or a subclass of a JContainer (JArray / JObject)");
-            }
+                if (type == typeof(string))
+                {
+                    typeEnum = TypeEnum.String;
+                }
+                else if (type.IsNumericType)
+                {
+                    typeEnum = TypeEnum.Number;
+                }
+                else if (type == typeof(bool))
+                {
+                    typeEnum = TypeEnum.Boolean;
+                }
+                else if (baseType.IsSubclassOf(typeof(JObject)) || baseType == typeof(JObject))
+                {
+                    typeEnum = TypeEnum.JSON;
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"{type} is not a valid type. Must be String / Number / Boolean or a subclass of a JObject");
+                }
 
-            return typeEnum;
+                return typeEnum;
+            }
+            catch (System.Exception e)
+            {
+                Console.WriteLine(variableValue);
+                Console.WriteLine(e);
+                throw e;
+            }
         }
     }
 }

--- a/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using TypeSupport.Extensions;
 
@@ -15,7 +13,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             var defaultValue = variable.DefaultValue ?? variable.Value;
             var value = variable.Value;
 
-            return new Variable<T>(variable.Id, variable.Key, variable.Type, (T) value)
+            return new Variable<T>(variable.Key, (T) value)
             {
                 DefaultValue = (T) defaultValue,
                 EvalReason = variable.EvalReason,
@@ -30,33 +28,33 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         /// <summary>
         /// Initializes a new instance of the <see cref="Variable" /> class.
         /// </summary>
-        /// <param name="id">unique database id (required).</param>
         /// <param name="key">Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id. (required).</param>
         /// <param name="type">Variable type (required).</param>
         /// <param name="value">Variable value can be a string, number, boolean, or JSON (required).</param>
-        public Variable(string id = default, string key = default, TypeEnum type = default, T value = default)
+        public Variable(string key = default, T value = default, T defaultValue = default)
         {
-            // to ensure "id" is required (not null)
-
-            Id = id ?? throw new InvalidDataException("id is a required property for Variable and cannot be null");
             // to ensure "key" is required (not null)
 
             Key = key ?? throw new InvalidDataException("key is a required property for Variable and cannot be null");
 
-            Type = type;
+            Type = DetermineType(value);
 
             // to ensure "value" is required (not null)
             Value = value ??
                     throw new InvalidDataException("value is a required property for Variable and cannot be null");
+            
+            DefaultValue = defaultValue ??
+                    throw new InvalidDataException("defaultValue is a required property for Variable and cannot be null");
 
             IsDefaulted = false;
         }
 
-        public Variable(string key, T defaultValue, string evalReason)
+        public Variable(string key, T defaultValue)
         {
             Key = key;
             Value = defaultValue;
-            EvalReason = evalReason;
+            DefaultValue = defaultValue;
+            Type = DetermineType(defaultValue);
             IsDefaulted = true;
         }
 
@@ -70,7 +68,6 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             var returnVariable = new Variable<T>();
             if (variable != null)
             {
-                returnVariable.Id = variable.Id;
                 returnVariable.Key = variable.Key;
                 returnVariable.Value = variable.Value;
                 returnVariable.Type = variable.Type;
@@ -94,34 +91,29 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         /// Variable value can be a string, number, boolean, or JSON
         /// </summary>
         /// <value>Variable value can be a string, number, boolean, or JSON</value>
-        [DataMember(Name = "value", EmitDefaultValue = false)]
+        [DataMember(Name = "value")]
         public T Value { get; set; }
 
+        [DataMember(Name = "defaultValue")]
         public T DefaultValue { get; set; }
 
         /// <summary>
         /// Variable type
         /// </summary>
         /// <value>Variable type</value>
-        [DataMember(Name="type", EmitDefaultValue=false)]
+        [DataMember(Name="type")]
         public TypeEnum Type { get; set; }
-        /// <summary>
-        /// unique database id
-        /// </summary>
-        /// <value>unique database id</value>
-        [DataMember(Name = "_id", EmitDefaultValue = false)]
-        public string Id { get; set; }
-        
+
         /// <summary>
         /// Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.
         /// </summary>
         /// <value>Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.</value>
-        [DataMember(Name = "key", EmitDefaultValue = false)]
+        [DataMember(Name = "key")]
         public string Key { get; set; }
         public bool IsDefaulted { get; set; }
         public string EvalReason { get; set; }
 
-        private static TypeEnum DetermineType(T variableType)
+        public static TypeEnum DetermineType(T variableType)
         {
             TypeEnum typeEnum;
             var type = variableType.GetType().GetExtendedType();

--- a/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
@@ -135,7 +135,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
                 {
                     typeEnum = TypeEnum.Boolean;
                 }
-                else if (baseType.IsSubclassOf(typeof(JObject)) || baseType == typeof(JObject))
+                else if (baseType.IsSubclassOf(typeof(JContainer)))
                 {
                     typeEnum = TypeEnum.JSON;
                 }

--- a/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
@@ -138,10 +138,10 @@ namespace DevCycle.SDK.Server.Local.MSTests
             var user = new User("j_test");
             string key = "json";
 
-            string json = "['Small','Medium','Large']";
-            var expectedValue = JArray.Parse(json);
+            string json = "{\"key\": \"value\"}";
+            var expectedValue = JObject.Parse(json);
 
-            var result = api.Variable(user, key, JArray.Parse(json));
+            var result = api.Variable(user, key, JObject.Parse(json));
 
             Assert.IsNotNull(result);
             Assert.IsTrue(result.IsDefaulted);

--- a/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
@@ -131,7 +131,25 @@ namespace DevCycle.SDK.Server.Local.MSTests
         }
 
         [TestMethod]
-        public void GetJsonVariableByKeyReturnsDefaultTest()
+        public void GetJsonVariableByKeyReturnsDefaultArrayTest()
+        {
+            using DVCLocalClient api = getTestClient();
+
+            var user = new User("j_test");
+            string key = "json";
+
+            string json = "['Small','Medium','Large']";
+            var expectedValue = JArray.Parse(json);
+
+            var result = api.Variable(user, key, JArray.Parse(json));
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.IsDefaulted);
+            Assert.AreEqual(expectedValue.ToString(), result.Value.ToString());
+        }
+        
+        [TestMethod]
+        public void GetJsonVariableByKeyReturnsDefaultObjectTest()
         {
             using DVCLocalClient api = getTestClient();
 


### PR DESCRIPTION
- use default value for cloud variable call when type from server is wrong compared to default value
- set type field correctly in all circumstances for local variables 
- ensure fields are always present for local variables