### PR TITLE
chore: replace Variable classes with ReadOnlyVariable in AllVariables usage

### DIFF
--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -126,7 +126,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             return variable;
         }
 
-        public async Task<Dictionary<string, Dictionary<string, object>>> AllVariablesAsync(User user)
+        public async Task<Dictionary<string, ReadOnlyVariable<object>>> AllVariablesAsync(User user)
         {
             ValidateUser(user);
 
@@ -137,7 +137,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             if (options.EnableEdgeDB) queryParams.Add("enableEdgeDB", "true");
 
 
-            return await GetResponseAsync<Dictionary<string, Dictionary<string, object>>>(user, urlFragment, queryParams);
+            return await GetResponseAsync<Dictionary<string, ReadOnlyVariable<object>>>(user, urlFragment, queryParams);
         }
 
         public async Task<DVCResponse> TrackAsync(User user, Event userEvent)

--- a/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DVCCloudClient.cs
@@ -126,7 +126,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             return variable;
         }
 
-        public async Task<Dictionary<string, Variable<object>>> AllVariablesAsync(User user)
+        public async Task<Dictionary<string, Dictionary<string, object>>> AllVariablesAsync(User user)
         {
             ValidateUser(user);
 
@@ -137,15 +137,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             if (options.EnableEdgeDB) queryParams.Add("enableEdgeDB", "true");
 
 
-            try
-            {
-                return await GetResponseAsync<Dictionary<string, Variable<object>>>(user, urlFragment, queryParams);
-            }
-            catch (DVCException e)
-            {
-                logger.LogError(e, "Failed to request AllVariables: ");
-                return new Dictionary<string, Variable<object>>();
-            }
+            return await GetResponseAsync<Dictionary<string, Dictionary<string, object>>>(user, urlFragment, queryParams);
         }
 
         public async Task<DVCResponse> TrackAsync(User user, Event userEvent)

--- a/DevCycle.SDK.Server.Common/Model/Local/BucketedUserConfig.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/BucketedUserConfig.cs
@@ -22,13 +22,15 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         public Dictionary<string, FeatureVariation> VariableVariationMap { get; set; }
         
         [DataMember(Name="variables", EmitDefaultValue=false)]
-        public Dictionary<string, Dictionary<string, object>> Variables { get; set; }
+        public Dictionary<string, ReadOnlyVariable<object>> InternalVariables { get; set; }
+        public VariableCollection Variables { get; private set; }
         
         [DataMember(Name="knownVariableKeys", EmitDefaultValue=false)]
         public List<decimal> KnownVariableKeys { get; set; }
         
         public void InitializeVariables()
         {
+            Variables = new VariableCollection(InternalVariables);
             if (FeatureVariationMap == null)
             {
                 FeatureVariationMap = new Dictionary<string, string>();

--- a/DevCycle.SDK.Server.Common/Model/Local/BucketedUserConfig.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/BucketedUserConfig.cs
@@ -22,16 +22,13 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         public Dictionary<string, FeatureVariation> VariableVariationMap { get; set; }
         
         [DataMember(Name="variables", EmitDefaultValue=false)]
-        public Dictionary<string, Variable<object>> InternalVariables { get; set; }
-        public VariableCollection Variables { get; private set; }
+        public Dictionary<string, Dictionary<string, object>> Variables { get; set; }
         
         [DataMember(Name="knownVariableKeys", EmitDefaultValue=false)]
         public List<decimal> KnownVariableKeys { get; set; }
         
         public void InitializeVariables()
         {
-            Variables = new VariableCollection(InternalVariables);
-
             if (FeatureVariationMap == null)
             {
                 FeatureVariationMap = new Dictionary<string, string>();

--- a/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 using Newtonsoft.Json.Linq;
@@ -87,6 +88,19 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             return returnVariable;
         }
 
+        public static Variable<T> InitializeFromVariableDictionary(
+            Dictionary<string, object> dictionary, 
+            T defaultValue
+        ) 
+        {
+            var returnVariable = new Variable<T>();
+            returnVariable.Key = (string)dictionary["key"];
+            returnVariable.Value = (T)dictionary["value"];
+            returnVariable.Type = DetermineType(defaultValue);
+            returnVariable.EvalReason = (string)dictionary["evalReason"];
+            returnVariable.IsDefaulted = false;
+            return returnVariable;
+        }
 
         /// <summary>
         /// Variable value can be a string, number, boolean, or JSON

--- a/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/Variable.cs
@@ -7,22 +7,6 @@ using TypeSupport.Extensions;
 
 namespace DevCycle.SDK.Server.Common.Model.Local
 {
-    public static class VariableHelper
-    {
-        public static Variable<T> Convert<T>(this Variable<object> variable)
-        {
-            var defaultValue = variable.DefaultValue ?? variable.Value;
-            var value = variable.Value;
-
-            return new Variable<T>(variable.Key, (T) value)
-            {
-                DefaultValue = (T) defaultValue,
-                EvalReason = variable.EvalReason,
-                IsDefaulted = variable.IsDefaulted,
-            };
-        }
-    }
-
     [DataContract]
     public class Variable<T> : IVariable
     {
@@ -59,6 +43,15 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             IsDefaulted = true;
         }
 
+        public Variable(ReadOnlyVariable<object> readOnlyVariable, T defaultValue)
+        {
+            Key = readOnlyVariable.Key;
+            Value = (T)readOnlyVariable.Value;
+            DefaultValue = defaultValue;
+            Type = DetermineType(defaultValue);
+            IsDefaulted = true;
+        }
+
         // parameterless private constructor for testing
         private Variable()
         {
@@ -85,20 +78,6 @@ namespace DevCycle.SDK.Server.Common.Model.Local
                 returnVariable.Type = DetermineType(defaultValue);
             }
 
-            return returnVariable;
-        }
-
-        public static Variable<T> InitializeFromVariableDictionary(
-            Dictionary<string, object> dictionary, 
-            T defaultValue
-        ) 
-        {
-            var returnVariable = new Variable<T>();
-            returnVariable.Key = (string)dictionary["key"];
-            returnVariable.Value = (T)dictionary["value"];
-            returnVariable.Type = DetermineType(defaultValue);
-            returnVariable.EvalReason = (string)dictionary["evalReason"];
-            returnVariable.IsDefaulted = false;
             return returnVariable;
         }
 

--- a/DevCycle.SDK.Server.Common/Model/Local/VariableCollection.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/VariableCollection.cs
@@ -4,9 +4,9 @@ namespace DevCycle.SDK.Server.Common.Model.Local
 {
     public class VariableCollection
     {
-        private readonly Dictionary<string, Variable<object>> variables;
+        private readonly Dictionary<string, ReadOnlyVariable<object>> variables;
 
-        public VariableCollection(Dictionary<string, Variable<object>> variables)
+        public VariableCollection(Dictionary<string, ReadOnlyVariable<object>> variables)
         {
             this.variables = variables;
         }
@@ -20,24 +20,16 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         /// Retrieve the Variable by key from the collection as the correct typeof T.
         /// Throws InvalidCastException if the requested conversion is incorrect
         /// </summary>
-        public Variable<T> Get<T>(string key)
+        public ReadOnlyVariable<object> Get(string key)
         {
-            Variable<T> existingVariable = null;
-
             if (!variables.ContainsKey(key))
                 throw new KeyNotFoundException(key);
             
             var variable = variables[key];
-            
-            if (variable != null)
-            {
-                existingVariable = variable.Convert<T>();
-            }
-
-            return existingVariable;
+            return variables[key];
         }
 
-        public Dictionary<string, Variable<object>> GetAll()
+        public Dictionary<string, ReadOnlyVariable<object>> GetAll()
         {
             return variables;
         }

--- a/DevCycle.SDK.Server.Common/Model/ReadOnlyVariable.cs
+++ b/DevCycle.SDK.Server.Common/Model/ReadOnlyVariable.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
+using DevCycle.SDK.Server.Common.Model.Local;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using TypeSupport.Extensions;
+
+namespace DevCycle.SDK.Server.Common.Model
+{
+    [DataContract]
+    public class ReadOnlyVariable<T>
+    {
+        /// <summary>
+        /// Variable value can be a string, number, boolean, or JSON
+        /// </summary>
+        /// <value>Variable value can be a string, number, boolean, or JSON</value>
+        [DataMember(Name = "value")]
+        [JsonProperty("value")]
+        public T Value { get; set; }
+
+        /// <summary>
+        /// Variable type
+        /// </summary>
+        /// <value>Variable type</value>
+        [DataMember(Name="type")]
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.
+        /// </summary>
+        /// <value>Unique key by Project, can be used in the SDK / API to reference by &#x27;key&#x27; rather than _id.</value>
+        [DataMember(Name = "key")]
+        [JsonProperty("key")]
+        public string Key { get; set; }
+        
+        public string EvalReason { get; set; }
+
+        /// <summary>
+        /// Returns the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class ReadOnlyVariable {\n");
+            sb.Append("  Key: ").Append(Key).Append("\n");
+            sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  Value: ").Append(Value).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.5.0" />
     <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta2" />
     <PackageReference Include="RestSharp" Version="108.0.2-alpha.0.6" />

--- a/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
@@ -14,6 +14,7 @@ using Newtonsoft.Json.Linq;
 using RestSharp;
 using RichardSzalay.MockHttp;
 using Environment = System.Environment;
+using System.Collections.Generic;
 
 namespace DevCycle.SDK.Server.Local.MSTests
 {
@@ -175,13 +176,12 @@ namespace DevCycle.SDK.Server.Local.MSTests
             // Bucketing needs time to work.
             await Task.Delay(5000);
             var result = api.AllVariables(user);
-        
-            Console.WriteLine(result);
+            
             Assert.IsTrue(result.ContainsKey("test"));
             Assert.IsNotNull(result);
-            var variable = result.Get<bool>("test");
+            var variable = result.Get("test");
             Assert.IsNotNull(variable);
-            Assert.IsTrue(variable.Value);
+            Assert.IsTrue((Boolean)variable.Value);
         }
 
         [TestMethod]

--- a/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
@@ -122,10 +122,8 @@ namespace DevCycle.SDK.Server.Local.Api
             {
                 try
                 {
-                    existingVariable = Common.Model.Local.Variable<T>.InitializeFromVariableDictionary(
-                        config?.Variables["key"], 
-                        defaultValue
-                    );
+                    ReadOnlyVariable<object> readOnlyVariable = config.Variables.Get(key);
+                    existingVariable = new Variable<T>(readOnlyVariable, defaultValue);
                 }
                 catch (InvalidCastException)
                 {
@@ -167,12 +165,12 @@ namespace DevCycle.SDK.Server.Local.Api
             }
         }
 
-        public Dictionary<string, Dictionary<string, object>> AllVariables(User user)
+        public VariableCollection AllVariables(User user)
         {
             if (!configManager.Initialized)
             {
                 logger.LogWarning("AllVariables called before DVCClient has initialized");
-                return new Dictionary<string, Dictionary<string, object>>();
+                return new VariableCollection(new Dictionary<string, ReadOnlyVariable<object>>());
             }
 
             var requestUser = new DVCPopulatedUser(user);
@@ -185,7 +183,7 @@ namespace DevCycle.SDK.Server.Local.Api
             catch (Exception e)
             {
                 logger.LogError("Unexpected exception retrieving variables from the config: {Exception}", e.Message);
-                return new Dictionary<string, Dictionary<string, object>>();
+                return new VariableCollection(new Dictionary<string, ReadOnlyVariable<object>>());
             }
         }
 

--- a/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
@@ -122,7 +122,10 @@ namespace DevCycle.SDK.Server.Local.Api
             {
                 try
                 {
-                    existingVariable = config.Variables.Get<T>(key);
+                    existingVariable = Common.Model.Local.Variable<T>.InitializeFromVariableDictionary(
+                        config?.Variables["key"], 
+                        defaultValue
+                    );
                 }
                 catch (InvalidCastException)
                 {
@@ -164,12 +167,12 @@ namespace DevCycle.SDK.Server.Local.Api
             }
         }
 
-        public VariableCollection AllVariables(User user)
+        public Dictionary<string, Dictionary<string, object>> AllVariables(User user)
         {
             if (!configManager.Initialized)
             {
                 logger.LogWarning("AllVariables called before DVCClient has initialized");
-                return new VariableCollection(new Dictionary<string, Variable<object>>());
+                return new Dictionary<string, Dictionary<string, object>>();
             }
 
             var requestUser = new DVCPopulatedUser(user);
@@ -182,7 +185,7 @@ namespace DevCycle.SDK.Server.Local.Api
             catch (Exception e)
             {
                 logger.LogError("Unexpected exception retrieving variables from the config: {Exception}", e.Message);
-                return new VariableCollection(new Dictionary<string, Variable<object>>());
+                return new Dictionary<string, Dictionary<string, object>>();
             }
         }
 


### PR DESCRIPTION
# Summary

Replace Variable class returned in `AllVariables` with a generic `Dictionary<string, object>`