### PR TITLE
fix null config for logging event before init

### DIFF
--- a/DevCycle.SDK.Server.Local/Api/EventQueue.cs
+++ b/DevCycle.SDK.Server.Local/Api/EventQueue.cs
@@ -143,7 +143,12 @@ namespace DevCycle.SDK.Server.Local.Api
                 logger.Log(LogLevel.Error, "Failed to queue an event. Events in queue exceeded the max");
                 return;
             }
-            localBucketing.QueueEvent(environmentKey, JsonConvert.SerializeObject(user), JsonConvert.SerializeObject(@event));
+            localBucketing.QueueEvent(
+                environmentKey, 
+                JsonConvert.SerializeObject(user), 
+                JsonConvert.SerializeObject(@event),
+                JsonConvert.SerializeObject(config?.VariableVariationMap ?? new Dictionary<string, FeatureVariation>())
+                );
             logger.LogInformation("{Event} queued successfully", @event);
         }
 
@@ -168,12 +173,12 @@ namespace DevCycle.SDK.Server.Local.Api
             {
                 throw new ArgumentException("UserId must be set");
             }
-
+            
             if (string.IsNullOrEmpty(@event.Target))
             {
                 throw new ArgumentException("Target must be set");
             }
-
+            
             if (@event.Type == string.Empty)
             {
                 throw new ArgumentException("Type must be set");
@@ -183,18 +188,10 @@ namespace DevCycle.SDK.Server.Local.Api
             eventCopy.Date = DateTimeOffset.UtcNow.DateTime;
             eventCopy.Value = 1;
 
-            var requestEvent = new DVCRequestEvent(
-                eventCopy,
-                user.UserId,
-                config == null ? new Dictionary<string, string>() : config.FeatureVariationMap
-            );
-
-            var userAndFeatureVars = new UserAndFeatureVars(user, requestEvent.FeatureVars);
-
             localBucketing.QueueAggregateEvent(
                 environmentKey,
                 JsonConvert.SerializeObject(@event),
-                JsonConvert.SerializeObject(config.VariableVariationMap)
+                JsonConvert.SerializeObject(config?.VariableVariationMap ?? new Dictionary<string, FeatureVariation>())
                 );
         }
 

--- a/DevCycle.SDK.Server.Local/Api/ILocalBucketing.cs
+++ b/DevCycle.SDK.Server.Local/Api/ILocalBucketing.cs
@@ -11,8 +11,8 @@ public interface ILocalBucketing
     public void OnPayloadFailure(string envKey, string payloadId, bool retryable);
     public BucketedUserConfig GenerateBucketedConfig(string token, string user);
     public int EventQueueSize(string envKey);
-    public void QueueEvent(string envKey, string user, string eventString);
-    public void QueueAggregateEvent(string envKey, string user, string eventString);
+    public void QueueEvent(string envKey, string user, string eventString, string variableVariationMapStr);
+    public void QueueAggregateEvent(string envKey, string eventString, string variableVariationMapStr);
     public void StoreConfig(string token, string config);
     public void SetPlatformData(string platformData);
 

--- a/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
+++ b/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
@@ -138,15 +138,16 @@ namespace DevCycle.SDK.Server.Local.Api
             return result;
         }
 
-        public void QueueEvent(string envKey, string user, string eventString)
+        public void QueueEvent(string envKey, string user, string eventString, string variableVariationMapStr)
         {
             WasmMutex.Wait();
             var envKeyAddress = GetParameter(envKey);
             var userAddress = GetParameter(user);
             var eventAddress = GetParameter(eventString);
+            var variableMapAddress = GetParameter(variableVariationMapStr);
 
             var initEventQueue = GetFunction("queueEvent");
-            initEventQueue.Invoke(envKeyAddress, userAddress, eventAddress);
+            initEventQueue.Invoke(envKeyAddress, userAddress, eventAddress, variableMapAddress);
             WasmMutex.Release();
         }
 


### PR DESCRIPTION
- fixes SDK throwing error when calling track before client finished initializing
- fixes not passing variable variations to the `QueueEvent` method