### PR TITLE
add request retry to cloud SDK

### DIFF
--- a/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
+++ b/DevCycle.SDK.Server.Common/API/DVCBaseClient.cs
@@ -52,13 +52,13 @@ namespace DevCycle.SDK.Server.Common.API
             }
         }
 
-        protected async Task<T> GetResponseAsync<T>(object body, string urlFragment, Dictionary<string, string> queryParams = null)
+        protected async Task<T> GetResponseAsync<T>(object body, string urlFragment, Dictionary<string, string> queryParams = null, bool shouldRetry = true)
         {
             RestResponse response = null;
             ErrorResponse errorResponse = null;
             try
             {
-                response = await GetApiClient().SendRequestAsync(body, urlFragment, queryParams);
+                response = await GetApiClient().SendRequestAsync(body, urlFragment, queryParams, shouldRetry);
                 if (response.IsSuccessful)
                 {
                     if (response.Content != null)

--- a/DevCycle.SDK.Server.Common/API/IDVCApiClient.cs
+++ b/DevCycle.SDK.Server.Common/API/IDVCApiClient.cs
@@ -10,6 +10,6 @@ namespace DevCycle.SDK.Server.Common.API
         public string GetServerSDKKey();
         public RestClient GetRestClient();
 
-        public Task<RestResponse> SendRequestAsync(object json, string urlFragment, Dictionary<string, string> queryParams = null);
+        public Task<RestResponse> SendRequestAsync(object json, string urlFragment, Dictionary<string, string> queryParams = null, bool shouldRetry = false);
     }
 }

--- a/DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
+++ b/DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
@@ -16,6 +16,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta2" />
+      <PackageReference Include="Polly" Version="7.2.3" />
       <PackageReference Include="RestSharp" Version="108.0.2-alpha.0.6" />
       <PackageReference Include="TypeSupport" Version="1.1.12" />
     </ItemGroup>

--- a/DevCycle.SDK.Server.Common/Policies/ClientPolicy.cs
+++ b/DevCycle.SDK.Server.Common/Policies/ClientPolicy.cs
@@ -1,0 +1,30 @@
+using Polly;
+using Polly.Retry;
+using Polly.Timeout;
+using Polly.Wrap;
+using RestSharp;
+using System;
+
+namespace DevCycle.SDK.Server.Common.Policies
+{
+    public class ClientPolicy
+    {
+        public AsyncPolicyWrap<RestResponse> RetryPolicyWithTimeout { get; }
+        private static ClientPolicy _instance = new ClientPolicy();
+
+        private ClientPolicy()
+        {
+            AsyncTimeoutPolicy timeoutPolicy = Policy.TimeoutAsync(5, TimeoutStrategy.Pessimistic);
+            AsyncRetryPolicy<RestResponse> retryPolicy = Policy
+                .HandleResult<RestResponse>(res => (int)res.StatusCode >= 500)
+                .WaitAndRetryAsync(5, retryAttempt => {
+                  var delay = Math.Pow(2, retryAttempt) * 100;
+                  var randomSum = delay * 0.2 * new Random().NextDouble();
+                  return TimeSpan.FromMilliseconds(delay + randomSum);
+                });
+            RetryPolicyWithTimeout = retryPolicy.WrapAsync(timeoutPolicy);
+        }
+
+        public static ClientPolicy GetInstance() => _instance;
+    }
+}


### PR DESCRIPTION
# Changes
* All cloud SDK methods now retry requests for a maximum of 5 times with an exponential backoff