### PR TITLE
fix: catch uncaught exception with deserializing config

### DIFF
--- a/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DVCTest.cs
@@ -24,7 +24,6 @@ namespace DevCycle.SDK.Server.Local.MSTests
         private DVCLocalClient getTestClient(
             DVCLocalOptions options = null)
         {
-            //string config = "{\"project\":{\"settings\":{\"edgeDB\":{\"enabled\":false}},\"_id\":\"6216420c2ea68943c8833c09\",\"key\":\"default\",\"a0_organization\":\"org_NszUFyWBFy7cr95J\"},\"environment\":{\"_id\":\"6216420c2ea68943c8833c0b\",\"key\":\"development\"},\"features\":[{\"_id\":\"6216422850294da359385e8b\",\"key\":\"test\",\"type\":\"release\",\"variations\":[{\"variables\":[{\"_var\":\"6216422850294da359385e8d\",\"value\":true}],\"name\":\"Variation On\",\"key\":\"variation-on\",\"_id\":\"6216422850294da359385e8f\"},{\"variables\":[{\"_var\":\"6216422850294da359385e8d\",\"value\":false}],\"name\":\"Variation Off\",\"key\":\"variation-off\",\"_id\":\"6216422850294da359385e90\"}],\"configuration\":{\"_id\":\"621642332ea68943c8833c4a\",\"targets\":[{\"distribution\":[{\"percentage\":0.5,\"_variation\":\"6216422850294da359385e8f\"},{\"percentage\":0.5,\"_variation\":\"6216422850294da359385e90\"}],\"_audience\":{\"_id\":\"621642332ea68943c8833c4b\",\"filters\":{\"operator\":\"and\",\"filters\":[{\"values\":[],\"type\":\"all\",\"filters\":[]}]}},\"_id\":\"621642332ea68943c8833c4d\"}],\"forcedUsers\":{}}}],\"variables\":[{\"_id\":\"6216422850294da359385e8d\",\"key\":\"test\",\"type\":\"Boolean\"}],\"variableHashes\":{\"test\":2447239932}}";
             string config = new string(Fixtures.Config());
             var mockHttp = new MockHttpMessageHandler();
 

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -205,6 +205,11 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
 
                 logger.LogError(finalError.ErrorResponse.Message);
                 dvcEventArgs.Errors.Add(finalError);
+            } catch (System.ArgumentNullException e) {
+                // This error can be thrown if the config is in an invalid format 
+                // from the method SetConfig
+                logger.LogError(e.Message);
+                dvcEventArgs.Errors.Add(new DVCException(new ErrorResponse(e.Message)));
             }
             finally
             {


### PR DESCRIPTION
# Summary

For cases when exception is not a `DVCException`, it was throwing an argument exception when deserializing the config string into a config object. Added an extra catch to catch any system exceptions not of type `DVCException`