### PR TITLE
chore: made app build a nullable type to prevent default 0.0 value

### DIFF
--- a/DevCycle.SDK.Server.Common/Model/Local/DVCPopulatedUser.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/DVCPopulatedUser.cs
@@ -28,8 +28,8 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         [JsonProperty("appVersion")]
         public string AppVersion;
         [DataMember(Name = "appBuild", EmitDefaultValue = false)]
-        [JsonProperty("appBuild")]
-        public double AppBuild;
+        [JsonProperty("appBuild", NullValueHandling=NullValueHandling.Ignore)]
+        public Nullable<double> AppBuild;
         [DataMember(Name = "customData", EmitDefaultValue = false)]
         [JsonProperty("customData")]
         public object CustomData;
@@ -88,7 +88,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             Language = user.Language;
             Country = user.Country;
             AppVersion = user.AppVersion;
-            AppBuild = user.AppBuild;
+            AppBuild = user.AppBuild > 0 ? user.AppBuild : (double?)null;
             CustomData = user.CustomData;
             PrivateCustomData = user.PrivateCustomData;
             LastSeenDate = DateTimeOffset.UtcNow.DateTime;


### PR DESCRIPTION
# Summary

Change type for `appBuild` from `double` to `Nullable<double>` to allow a null value to be used and to prevent `0.0` to be the default