### PR TITLE
fixed issue where Variable() method could return null

### DIFF
--- a/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DVCLocalClient.cs
@@ -245,7 +245,7 @@ namespace DevCycle.SDK.Server.Local.Api
             catch (Exception e)
             {
                 logger.LogError("Unexpected exception getting variable: {Exception}", e.Message);
-                return null;
+                return Common.Model.Local.Variable<T>.InitializeFromVariable(null, key, defaultValue);
             }
             return existingVariable;
         }


### PR DESCRIPTION
When an exception occurred during evaluation the exception would get logged but the function returned a null instead of a default value.