### PR TITLE
chore: update DVC SDK dep in example apps

### DIFF
--- a/DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
+++ b/DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevCycle.SDK.Server.Cloud" Version="1.10.0" />
+    <PackageReference Include="DevCycle.SDK.Server.Cloud" Version="1.10.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.11.0" />
-    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.8.0" />
+    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.11.2" />
+    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>


### PR DESCRIPTION
# Changes
* Update examples apps to use the latest version of DVC dotnet SDK