### PR TITLE
feat: upgrade wasmtime and add netstandard2.0 local bucketing support

### DIFF
--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '4.0.x'
+          dotnet-version: |
+            6.0.x
+            2.0.x
       - name: Restore dependencies
         run: | 
           dotnet restore

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -8,14 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
-          include-prerelease: true
+          dotnet-version: '4.0.x'
       - name: Restore dependencies
         run: | 
           dotnet restore
@@ -24,7 +23,7 @@ jobs:
           dotnet build --no-restore
       - name: Run Local Example
         run: |
-          dotnet run --no-build --verbosity normal --project ./DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
         env:
           DVC_SERVER_SDK_KEY: "${{ secrets.DEVCYCLE_SERVER_SDK_KEY }}"
 #      - name: Run Cloud Example

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
         env:
-          DVC_SERVER_SDK_KEY: "${{ secrets.DEVCYCLE_SERVER_SDK_KEY }}"
+          DVC_SERVER_SDK_KEY: "${{ secrets.EXAMPLE_DEVCYCLE_SERVER_SDK_KEY }}"
 #      - name: Run Cloud Example
 #        run: |
 #          dotnet run --no-build --verbosity normal --project ./DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -27,9 +27,9 @@ jobs:
           dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
         env:
           DVC_SERVER_SDK_KEY: "${{ secrets.EXAMPLE_DEVCYCLE_SERVER_SDK_KEY }}"
-#      - name: Run Cloud Example
-#        run: |
-#          dotnet run --no-build --verbosity normal --project ./DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
-#        env:
-#          DVC_SERVER_SDK_KEY: "${{ secrets.DEVCYCLE_SERVER_SDK_KEY }}"
+      - name: Run Cloud Example
+        run: |
+          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
+        env:
+          DVC_SERVER_SDK_KEY: "${{ secrets.EXAMPLE_DEVCYCLE_SERVER_SDK_KEY }}"
           

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            2.0.x
       - name: Restore dependencies
         run: | 
           dotnet restore

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -1,4 +1,4 @@
-name: Test Local Bucketing Example
+name: Verify Examples
 
 on:
   push:
@@ -16,11 +16,20 @@ jobs:
         with:
           dotnet-version: '6.0.x'
           include-prerelease: true
-      - name: Navigate to Example
-        run: cd DevCycle.SDK.Server.Local.Example
       - name: Restore dependencies
-        run: dotnet restore
+        run: | 
+          dotnet restore
       - name: Build
-        run: dotnet build --no-restore
-      - name: Test Example
-        run: dotnet run --no-build --verbosity normal
+        run: |
+          dotnet build --no-restore
+      - name: Run Local Example
+        run: |
+          dotnet run --no-build --verbosity normal --project ./DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+        env:
+          DVC_SERVER_SDK_KEY: "${{ secrets.DEVCYCLE_SERVER_SDK_KEY }}"
+#      - name: Run Cloud Example
+#        run: |
+#          dotnet run --no-build --verbosity normal --project ./DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
+#        env:
+#          DVC_SERVER_SDK_KEY: "${{ secrets.DEVCYCLE_SERVER_SDK_KEY }}"
+          

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -1,0 +1,26 @@
+name: Test Local Bucketing Example
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
+      - name: Navigate to Example
+        run: cd DevCycle.SDK.Server.Local.Example
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test Example
+        run: dotnet run --no-build --verbosity normal

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: |
-            3.1.X
+          dotnet-version: 3.1.x
       - name: Restore dependencies
         run: |
           dotnet restore

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   run-example:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
 
@@ -20,7 +20,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1
 
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.2
+        uses: NuGet/setup-nuget@v1
 
       - name: Navigate to SDK.Server.Common
         run: cd $GITHUB_WORKSPACE/DevCycle.SDK.Server.Common

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
 
-#      - name: Navigate to SDK.Server.Common
-#        run: cd DevCycle.SDK.Server.Common
-
       - name: Common - Restore Packages
         run: |
           cd DevCycle.SDK.Server.Common
@@ -34,31 +31,23 @@ jobs:
         run: |
           cd DevCycle.SDK.Server.Common
           msbuild.exe DevCycle.SDK.Server.Common.csproj /p:configuration="Release"
-#
-#      - name: Navigate to SDK.Server.Local
-#        run: cd $GITHUB_WORKSPACE/DevCycle.SDK.Server.Local 
-#
-#      - name: Local - Restore Packages
-#        run: |
-#          nuget restore DevCycle.SDK.Server.Local.csproj
-#
-#      - name: Local - Build
-#        run: |
-#          msbuild.exe DevCycle.SDK.Server.Local.csproj /p:configuration="Release"
-#      
-#  
-#      - name: Setup .NET
-#        uses: actions/setup-dotnet@v2
-#        with:
-#          dotnet-version:  "6.0.x"
-#      - name: Build
-#        run: |
-#          dotnet build
-#      - name: Run Local Example
-#        run: |
-#          dotnet run --no-build --configuration Release --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
-#      - name: Run Cloud Example
-#        run: |
-#          dotnet run --no-build --configuration Release --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
-#          
-          
+
+      - name: Local - Restore Packages
+        run: |
+          cd DevCycle.SDK.Server.Local
+          nuget restore DevCycle.SDK.Server.Local.csproj
+
+      - name: Local - Build
+        run: |
+          cd DevCycle.SDK.Server.Local
+          msbuild.exe DevCycle.SDK.Server.Local.csproj /p:configuration="Release"
+
+      - name: Example - Restore Packages
+        run: |
+          cd DevCycle.SDK.Server.Local.Example
+          nuget restore DevCycle.SDK.Server.Local.Example.csproj
+
+      - name: Example - Build
+        run: |
+          cd DevCycle.SDK.Server.Local.Example
+          msbuild.exe DevCycle.SDK.Server.Local.Example.csproj /p:configuration="Release"

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -13,15 +13,12 @@ env:
 jobs:
   run:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: [ "5.0", "6.0.x" ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version:  "6.0.x"
       - name: Restore dependencies
         run: |
           dotnet restore

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -12,42 +12,21 @@ env:
 
 jobs:
   run-example:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
-
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1
-
-      - name: Common - Restore Packages
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version:  "6.0.x"
+      - name: Build
         run: |
-          cd DevCycle.SDK.Server.Common
-          nuget restore DevCycle.SDK.Server.Common.csproj
-
-      - name: Common - Build
+          dotnet build
+      - name: Run Local Example
         run: |
-          cd DevCycle.SDK.Server.Common
-          msbuild.exe DevCycle.SDK.Server.Common.csproj /p:configuration="Release"
-
-      - name: Local - Restore Packages
+          dotnet run --configuration Release --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
+      - name: Run Cloud Example
         run: |
-          cd DevCycle.SDK.Server.Local
-          nuget restore DevCycle.SDK.Server.Local.csproj
+          dotnet run --configuration Release --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
 
-      - name: Local - Build
-        run: |
-          cd DevCycle.SDK.Server.Local
-          msbuild.exe DevCycle.SDK.Server.Local.csproj /p:configuration="Release"
-
-      - name: Example - Restore Packages
-        run: |
-          cd DevCycle.SDK.Server.Local.Example
-          nuget restore DevCycle.SDK.Server.Local.Example.csproj
-
-      - name: Example - Build
-        run: |
-          cd DevCycle.SDK.Server.Local.Example
-          msbuild.exe DevCycle.SDK.Server.Local.Example.csproj /p:configuration="Release"
+          

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -15,18 +15,48 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version:  "6.0.x"
-      - name: Build
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.2
+
+      - name: Navigate to SDK.Server.Common
+        run: cd $GITHUB_WORKSPACE/DevCycle.SDK.Server.Common
+
+      - name: Common - Restore Packages
         run: |
-          dotnet build
-      - name: Run Local Example
+          nuget restore DevCycle.SDK.Server.Common.csproj
+
+      - name: Common - Build
         run: |
-          dotnet run --configuration Release --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
+          msbuild.exe DevCycle.SDK.Server.Common.csproj /p:configuration="Release"
+#
+#      - name: Navigate to SDK.Server.Local
+#        run: cd $GITHUB_WORKSPACE/DevCycle.SDK.Server.Local 
+#
+#      - name: Local - Restore Packages
+#        run: |
+#          nuget restore DevCycle.SDK.Server.Local.csproj
+#
+#      - name: Local - Build
+#        run: |
+#          msbuild.exe DevCycle.SDK.Server.Local.csproj /p:configuration="Release"
+#      
+#  
+#      - name: Setup .NET
+#        uses: actions/setup-dotnet@v2
+#        with:
+#          dotnet-version:  "6.0.x"
+#      - name: Build
+#        run: |
+#          dotnet build
+#      - name: Run Local Example
+#        run: |
+#          dotnet run --no-build --configuration Release --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
 #      - name: Run Cloud Example
 #        run: |
-#          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
+#          dotnet run --no-build --configuration Release --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
 #          
           

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -24,7 +24,7 @@ jobs:
           dotnet build
       - name: Run Local Example
         run: |
-          dotnet run --verbosity diag --configuration Release --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
+          dotnet run --configuration Release --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
 #      - name: Run Cloud Example
 #        run: |
 #          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -22,17 +22,17 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
 
-      - name: Navigate to SDK.Server.Common
-        run: cd DevCycle.SDK.Server.Common
+#      - name: Navigate to SDK.Server.Common
+#        run: cd DevCycle.SDK.Server.Common
 
       - name: Common - Restore Packages
         run: |
-          pwd
-          dir
+          cd DevCycle.SDK.Server.Common
           nuget restore DevCycle.SDK.Server.Common.csproj
 
       - name: Common - Build
         run: |
+          cd DevCycle.SDK.Server.Common
           msbuild.exe DevCycle.SDK.Server.Common.csproj /p:configuration="Release"
 #
 #      - name: Navigate to SDK.Server.Local

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -19,18 +19,12 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version:  "6.0.x"
-      - name: Restore dependencies
-        run: |
-          dotnet restore
       - name: Build
         run: |
-          dotnet build --no-restore
-      - name: Debug
-        run: |
-          dir DevCycle.SDK.Server.Local.Example\bin\Debug\net48
+          dotnet build
       - name: Run Local Example
         run: |
-          dotnet run --no-build --verbosity diag --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
+          dotnet run --verbosity diag --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
 #      - name: Run Cloud Example
 #        run: |
 #          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -23,7 +23,7 @@ jobs:
         uses: NuGet/setup-nuget@v1
 
       - name: Navigate to SDK.Server.Common
-        run: cd $GITHUB_WORKSPACE/DevCycle.SDK.Server.Common
+        run: cd DevCycle.SDK.Server.Common
 
       - name: Common - Restore Packages
         run: |

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -25,11 +25,21 @@ jobs:
       - name: Build
         run: |
           dotnet build --no-restore
-      - name: Run Local Example
+      - name: Debug
         run: |
-          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
-      - name: Run Cloud Example
-        run: |
-          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
-          
+          dir DevCycle.SDK.Server.Local.Example\bin\Debug\net48 > test.txt
+      - name: Read file
+        id: readfile
+        uses: komorebitech/read-files-action@v1.5
+        with:
+          files: '["test.txt"]'
+      - name: Echo file
+        run: echo "${{ steps.readfile.outputs.content }}"
+#      - name: Run Local Example
+#        run: |
+#          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
+#      - name: Run Cloud Example
+#        run: |
+#          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
+#          
           

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -13,12 +13,15 @@ env:
 jobs:
   run:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        dotnet-version: [ "5.0", "6.0.x" ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Restore dependencies
         run: |
           dotnet restore

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -11,7 +11,7 @@ env:
   DVC_SERVER_SDK_KEY: "${{ secrets.EXAMPLE_DEVCYCLE_SERVER_SDK_KEY }}"
 
 jobs:
-  run:
+  run-example:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,17 +27,10 @@ jobs:
           dotnet build --no-restore
       - name: Debug
         run: |
-          dir DevCycle.SDK.Server.Local.Example\bin\Debug\net48 > test.txt
-      - name: Read file
-        id: readfile
-        uses: komorebitech/read-files-action@v1.5
-        with:
-          files: '["test.txt"]'
-      - name: Echo file
-        run: echo "${{ steps.readfile.outputs.content }}"
-#      - name: Run Local Example
-#        run: |
-#          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
+          dir DevCycle.SDK.Server.Local.Example\bin\Debug\net48
+      - name: Run Local Example
+        run: |
+          dotnet run --no-build --verbosity diag --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
 #      - name: Run Cloud Example
 #        run: |
 #          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Common - Restore Packages
         run: |
+          pwd
+          dir
           nuget restore DevCycle.SDK.Server.Common.csproj
 
       - name: Common - Build

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -1,4 +1,4 @@
-name: Verify Examples
+name: Test Run Examples
 
 on:
   push:
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  # Using the DevCycle Internal Default key
+  DVC_SERVER_SDK_KEY: "${{ secrets.EXAMPLE_DEVCYCLE_SERVER_SDK_KEY }}"
+
 jobs:
-  build:
+  run:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,9 +19,9 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            6.0.x
+            3.1.X
       - name: Restore dependencies
-        run: | 
+        run: |
           dotnet restore
       - name: Build
         run: |
@@ -25,11 +29,8 @@ jobs:
       - name: Run Local Example
         run: |
           dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
-        env:
-          DVC_SERVER_SDK_KEY: "${{ secrets.EXAMPLE_DEVCYCLE_SERVER_SDK_KEY }}"
       - name: Run Cloud Example
         run: |
           dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj
-        env:
-          DVC_SERVER_SDK_KEY: "${{ secrets.EXAMPLE_DEVCYCLE_SERVER_SDK_KEY }}"
+          
           

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -24,7 +24,7 @@ jobs:
           dotnet build
       - name: Run Local Example
         run: |
-          dotnet run --verbosity diag --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
+          dotnet run --verbosity diag --configuration Release --project .\DevCycle.SDK.Server.Local.Example\DevCycle.SDK.Server.Local.Example.csproj
 #      - name: Run Cloud Example
 #        run: |
 #          dotnet run --no-build --verbosity normal --project .\DevCycle.SDK.Server.Cloud.Example\DevCycle.SDK.Server.Cloud.Example.csproj

--- a/DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
+++ b/DevCycle.SDK.Server.Cloud.Example/DevCycle.SDK.Server.Cloud.Example.csproj
@@ -2,7 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <!-- Uncomment the following line to test with .NET 4.8
     <TargetFramework>net48</TargetFramework>
+    -->
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <RootNamespace>Example</RootNamespace>
   </PropertyGroup>
@@ -13,8 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevCycle.SDK.Server.Cloud" Version="1.10.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DevCycle.SDK.Server.Common\DevCycle.SDK.Server.Common.csproj" />
+    <ProjectReference Include="..\DevCycle.SDK.Server.Cloud\DevCycle.SDK.Server.Cloud.csproj" />
   </ItemGroup>
 </Project>

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -13,8 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.11.2" />
-    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-<!--    <TargetFramework>net48</TargetFramework>-->
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <RootNamespace>Example</RootNamespace>
   </PropertyGroup>
@@ -14,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.11.2" />
-    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.8.2" />
+<!--    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.11.2" />-->
+<!--    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.8.2" />-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <RootNamespace>Example</RootNamespace>
   </PropertyGroup>

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-<!--    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.11.2" />-->
-<!--    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.8.2" />-->
+    <PackageReference Include="DevCycle.SDK.Server.Common" Version="1.11.2" />
+    <PackageReference Include="DevCycle.SDK.Server.Local" Version="2.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+<!--    <TargetFramework>net48</TargetFramework>-->
+    <TargetFramework>net6.0</TargetFramework>
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <RootNamespace>Example</RootNamespace>
   </PropertyGroup>

--- a/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
+++ b/DevCycle.SDK.Server.Local.Example/DevCycle.SDK.Server.Local.Example.csproj
@@ -2,7 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <!-- Uncomment the following line to test with .NET 4.8
     <TargetFramework>net48</TargetFramework>
+    -->
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <RootNamespace>Example</RootNamespace>
   </PropertyGroup>

--- a/DevCycle.SDK.Server.Local.Example/Program.cs
+++ b/DevCycle.SDK.Server.Local.Example/Program.cs
@@ -64,6 +64,8 @@ namespace Example
 
             Console.WriteLine(api.Variable(user, "test-variable", true));
             Console.WriteLine(api.AllVariables(user));
+            
+            api.Dispose();
         }
     }
 }

--- a/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
+++ b/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
@@ -535,7 +535,7 @@ namespace DevCycle.SDK.Server.Local.Api
             #if NETSTANDARD2_0
             Span<byte> span = memory.GetSpan<byte>(address, length);
             return Encoding.Unicode.GetString(span.ToArray());
-            #else 
+            #elif NETSTANDARD2_1
             return Encoding.Unicode.GetString(memory.GetSpan(address, length));
             #endif 
         }

--- a/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
+++ b/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
@@ -433,7 +433,7 @@ namespace DevCycle.SDK.Server.Local.Api
             var paramAddress = (int)NewFunc.Invoke(data.Length, WasmObjectIdString)!;
             Span<byte> paramSpan = WASMMemory.GetSpan<byte>(paramAddress, data.Length);
             data.CopyTo(paramSpan);
-            #else
+            #elif NETSTANDARD2_1
             var paramAddress = (int)NewFunc.Invoke(Encoding.Unicode.GetByteCount(param), WasmObjectIdString)!;
             Encoding.Unicode.GetBytes(param, WASMMemory.GetSpan(paramAddress, Encoding.Unicode.GetByteCount(param)));
             #endif

--- a/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
+++ b/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
@@ -123,18 +123,20 @@ namespace DevCycle.SDK.Server.Local.Api
                         Console.WriteLine(message);
                     })
             );
+            
             WASMLinker.Define(
                 "env",
                 "Date.now",
                 Function.FromCallback(WASMStore,
-                    (Caller _) => (DateTime.Now.ToUniversalTime() - DateTime.UnixEpoch).TotalMilliseconds)
+                    (Caller _) => Convert.ToDouble(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+                    )
             );
             WASMLinker.Define(
                 "env",
                 "seed",
                 Function.FromCallback(WASMStore,
-                    (Caller _) =>
-                        (random.NextDouble() * (DateTime.Now.ToUniversalTime() - DateTime.UnixEpoch).TotalMilliseconds))
+                    (Caller _) => (random.NextDouble() * DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+                )
             );
 
             WASMInstance = WASMLinker.Instantiate(WASMStore, WASMModule);
@@ -426,10 +428,13 @@ namespace DevCycle.SDK.Server.Local.Api
 
         private int GetParameter(string param)
         {
+            byte[] data = Encoding.Unicode.GetBytes(param);
+            
             var paramAddress =
-                (int)NewFunc.Invoke(Encoding.Unicode.GetByteCount(param), WasmObjectIdString)!;
-
-            Encoding.Unicode.GetBytes(param, WASMMemory.GetSpan(paramAddress, Encoding.Unicode.GetByteCount(param)));
+                (int)NewFunc.Invoke(data.Length, WasmObjectIdString)!;
+            
+            Span<byte> paramSpan = WASMMemory.GetSpan<byte>(paramAddress, data.Length);
+            data.CopyTo(paramSpan);
 
             return paramAddress;
         }
@@ -525,7 +530,8 @@ namespace DevCycle.SDK.Server.Local.Api
         {
             // The byte length of the string is at offset -4 in AssemblyScript string layout.
             var length = memory.ReadInt32(address - 4);
-            return Encoding.Unicode.GetString(memory.GetSpan(address, length));
+            Span<byte> span = memory.GetSpan<byte>(address, length);
+            return Encoding.Unicode.GetString(span.ToArray());
         }
 
         private static byte[] ReadAssemblyScriptByteArray(Memory memory, int address)

--- a/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
+++ b/DevCycle.SDK.Server.Local/Api/LocalBucketing.cs
@@ -69,7 +69,7 @@ namespace DevCycle.SDK.Server.Local.Api
             pinnedAddresses = new HashSet<int>();
             sdkKeyAddresses = new Dictionary<string, int>();
             
-            Console.WriteLine("Initializing .NETStandard2.1 Local Bucketing");
+            Console.WriteLine("Initializing Local Bucketing");
             Assembly assembly = typeof(LocalBucketing).GetTypeInfo().Assembly;
             
             Stream wasmResource = assembly.GetManifestResourceStream("DevCycle.bucketing-lib.release.wasm");

--- a/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
+++ b/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
@@ -29,7 +29,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
+++ b/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
@@ -29,7 +29,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
+++ b/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
@@ -29,7 +29,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -45,7 +45,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Wasmtime" Version="3.0.0" />
+    <PackageReference Include="Wasmtime" Version="11.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Welcome to the DevCycle .NET Server SDK, which interfaces with a local bucketing library. This SDK requests config from DevCycle servers on DVCClient initialization. 
 All calls to the client will then perform local bucketing to determine if a user receives a specific variation.
 Events are queued and flushed periodically in the background.
-This version uses .NET Standard 2.1 and utilizes more resources to perform local bucketing.
+This version uses .NET Standard 2.0 and utilizes more resources to perform local bucketing.
 
 ## Installation
 Download the SDK from Nuget - https://www.nuget.org/packages/DevCycle.SDK.Server.Local/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Welcome to the DevCycle .NET Server SDK, which interfaces with a local bucketing library. This SDK requests config from DevCycle servers on DVCClient initialization. 
 All calls to the client will then perform local bucketing to determine if a user receives a specific variation.
 Events are queued and flushed periodically in the background.
-This version uses .NET Standard 2.0 and utilizes more resources to perform local bucketing.
+This version is compatible with .NET Standard 2.0 and utilizes more resources to perform local bucketing.
 
 ## Installation
 Download the SDK from Nuget - https://www.nuget.org/packages/DevCycle.SDK.Server.Local/


### PR DESCRIPTION
- upgrading wasmtime from 3.0.0 to 11.0.1
- Added netstandard2.0 as a build target for DVCLocalClient now that wasmtime can support it