### PR TITLE
ci: temporary tweak to bump major versions on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,8 @@ jobs:
         run: dotnet nuget push DevCycle.SDK.Server.Cloud/bin/Release/DevCycle.SDK.Server.Cloud.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
       - name: Publish Common to NuGet
         run: dotnet nuget push DevCycle.SDK.Server.Common/bin/Release/DevCycle.SDK.Server.Common.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
-      - name: Create GitHub Release
-        uses: DevCycleHQ/release-action/gh-release@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+# Release action doesn't work right now for this repo due to the multiple different project versions
+#      - name: Create GitHub Release
+#        uses: DevCycleHQ/release-action/gh-release@v2
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,9 +46,9 @@ jobs:
           version: ${{ steps.local-version.outputs.version }}
       - name: Replace the versions for all SDKs
         run: |
-          sed -E -i "s|<(.*)Version>[0-9]+\.[0-9]+\.[0-9]|<\1Version>${{ steps.semverbump-cloud.outputs.minor }}|g" DevCycle.SDK.Server.Cloud/DevCycle.SDK.Server.Cloud.csproj
-          sed -E -i "s|<(.*)Version>[0-9]+\.[0-9]+\.[0-9]|<\1Version>${{ steps.semverbump-common.outputs.minor }}|g" DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
-          sed -E -i "s|<(.*)Version>[0-9]+\.[0-9]+\.[0-9]|<\1Version>${{ steps.semverbump-local.outputs.minor }}|g" DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
+          sed -E -i "s|<(.*)Version>[0-9]+\.[0-9]+\.[0-9]|<\1Version>${{ steps.semverbump-cloud.outputs.major }}|g" DevCycle.SDK.Server.Cloud/DevCycle.SDK.Server.Cloud.csproj
+          sed -E -i "s|<(.*)Version>[0-9]+\.[0-9]+\.[0-9]|<\1Version>${{ steps.semverbump-common.outputs.major }}|g" DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
+          sed -E -i "s|<(.*)Version>[0-9]+\.[0-9]+\.[0-9]|<\1Version>${{ steps.semverbump-local.outputs.major }}|g" DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
           git add .
           git commit -m "Version Bumping"
           git push -u origin main


### PR DESCRIPTION
Next release needs to be a major version bump as we are doing a major API refactor