### PR TITLE
fix: tweaks to logging and updated README

### DIFF
--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -8,10 +8,8 @@ using DevCycle.SDK.Server.Common.Model.Local;
 using DevCycle.SDK.Server.Local.ConfigManager;
 using DevCycle.SDK.Server.Local.Protobuf;
 using Google.Protobuf;
-using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace DevCycle.SDK.Server.Local.Api
 {

--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -46,8 +46,12 @@ namespace DevCycle.SDK.Server.Local.Api
 
             options ??= new DevCycleLocalOptions();
 
-            loggerFactory ??= LoggerFactory.Create(builder => builder.AddConsole());
-
+            loggerFactory ??= LoggerFactory.Create(builder => builder.AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = false;
+                options.SingleLine = true;
+            }));
+            
             configManager ??= new EnvironmentConfigManager(sdkKey, options, loggerFactory, localBucketing,
                 initialized, restClientOptions);
 

--- a/DevCycle.SDK.Server.Local/Api/EventQueue.cs
+++ b/DevCycle.SDK.Server.Local/Api/EventQueue.cs
@@ -158,7 +158,7 @@ namespace DevCycle.SDK.Server.Local.Api
                 JsonConvert.SerializeObject(user), 
                 JsonConvert.SerializeObject(@event)
                 );
-            logger.LogInformation("{Event} queued successfully", @event);
+            logger.LogDebug("{Event} queued successfully", @event);
         }
 
         /**

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -172,7 +172,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
             }
             else if (res.StatusCode == HttpStatusCode.NotModified)
             {
-                logger.LogInformation("Config not modified, using cache, etag: {ConfigEtag}", configEtag);
+                logger.LogDebug("Config not modified, using cache, etag: {ConfigEtag}", configEtag);
             }
             else
             {

--- a/README.md
+++ b/README.md
@@ -15,3 +15,26 @@ Your DevCycle SDK key can be found via [Environments & Keys Settings](https://ww
 
 ## Usage
 To find usage documentation, visit our docs for [Local Bucketing](https://docs.devcycle.com/docs/sdk/server-side-sdks/dotnet-local).
+
+
+## Logging
+
+The DevCycle SDK uses [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.2) for logging and logs to **stdout** by default. You can customize the logging by providing your own ILoggingFactory when creating the `DevCycleLocalClient`.
+
+```csharp
+var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder
+        .AddConsole() // Configure the logger to output to the console
+        .SetMinimumLevel(LogLevel.Information); // Set the minimum log level to Information
+});
+
+client = new DevCycleLocalClientBuilder()
+    .SetSDKKey("<DEVCYCLE_SERVER_SDK_KEY>")
+    .SetOptions(options ?? new DevCycleLocalOptions())
+    .SetOptions(new DevCycleLocalOptions(configPollingIntervalMs: 60000, eventFlushIntervalMs: 60000))
+    .SetLogger(loggerFactory)
+    .Build();
+```
+
+


### PR DESCRIPTION
* added logging override example to the README
* changed default logger to format to 1 line
* Reduced logging level to Debug for when EnvironmentConfigManager gets a 304 Not Modified from the CDN
* Reduced logging level to Debug when adding an event