### PR TITLE
chore(dep): Update Microsoft.Extensions.Logging.Console from 6.0.0 to 7.0.0

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycle.SDK.Server.Cloud.MSTests.csproj
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycle.SDK.Server.Cloud.MSTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />

--- a/DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
+++ b/DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Polly" Version="7.2.3" />
       <PackageReference Include="RestSharp" Version="110.2.0" />

--- a/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
+++ b/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
@@ -48,8 +48,8 @@
     <PackageReference Include="Wasmtime" Version="11.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Had to do this manually because the bump needed to update `Microsoft.Extensions.Logging.Abstractions` at the same time