### PR TITLE
chore: update 'platform' to return 'C#' not including 'Local' / 'Cloud' to match other SDK formats.

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycleTest.cs
@@ -167,7 +167,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
 
         private void AssertUserDefaultsCorrect(DevCycleUser user)
         {
-            Assert.AreEqual("C# Cloud", user.Platform);
+            Assert.AreEqual("C#", user.Platform);
             Assert.AreEqual(DevCycleUser.SdkTypeEnum.Server, user.SdkType);
             //Assert.AreEqual("1.0.3.0", user.SdkVersion);
         }

--- a/DevCycle.SDK.Server.Common/API/DevCycleBaseClient.cs
+++ b/DevCycle.SDK.Server.Common/API/DevCycleBaseClient.cs
@@ -13,7 +13,7 @@ namespace DevCycle.SDK.Server.Common.API
 {
     public abstract class DevCycleBaseClient : IDevCycleClient 
     {
-        public string SdkPlatform => $"C# {Platform()}";
+        public string SdkPlatform => $"C#";
         private static string CSharpVersion => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
         private static string SdkVersion => typeof(IDevCycleClient).Assembly.GetName().Version.ToString();
         private static DevCycleUser.SdkTypeEnum SdkType => DevCycleUser.SdkTypeEnum.Server;

--- a/DevCycle.SDK.Server.Common/Model/Local/PlatformData.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/PlatformData.cs
@@ -4,8 +4,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
 {
     public class PlatformData
     {
-
-        private const string DefaultPlatform = "C# Local";
+        private const string DefaultPlatform = "C#";
         private const DevCycleUser.SdkTypeEnum DefaultSdkType = DevCycleUser.SdkTypeEnum.Server;
         
         private static readonly string DefaultSdkVersion = typeof(DevCyclePopulatedUser).Assembly.GetName().Version.ToString();


### PR DESCRIPTION
Renaming the `platform` field to just return `C#` to match other SDKs. We will send the `Local` / `Cloud` details through a new `metaData` format.