### PR TITLE
chore: Change initialization config check to not be blind.

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycle.SDK.Server.Cloud.MSTests.csproj
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycle.SDK.Server.Cloud.MSTests.csproj
@@ -6,7 +6,7 @@
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DevCycle.SDK.Server.Common/Model/Local/DevCycleLocalOptions.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/DevCycleLocalOptions.cs
@@ -59,8 +59,8 @@ namespace DevCycle.SDK.Server.Common.Model.Local
 
         
         public DevCycleLocalOptions(
-            int configPollingIntervalMs = 1000,
-            int configPollingTimeoutMs = 5000,
+            int configPollingIntervalMs = 5000,
+            int configPollingTimeoutMs = 1000,
             string cdnUri = "https://config-cdn.devcycle.com",
             string cdnSlug = "",
             string eventsApiUri = "https://events.devcycle.com",

--- a/DevCycle.SDK.Server.Local.Benchmark/DevCycle.SDK.Server.Local.Benchmark.csproj
+++ b/DevCycle.SDK.Server.Local.Benchmark/DevCycle.SDK.Server.Local.Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycle.SDK.Server.Local.MSTests.csproj
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycle.SDK.Server.Local.MSTests.csproj
@@ -6,7 +6,7 @@
     <ReleaseVersion>1.0.1</ReleaseVersion>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
@@ -116,7 +116,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
             var result = await api.AllFeatures(user);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(4, result.Count);
             Assert.IsNotNull(result["test"]);
             Assert.IsFalse(string.IsNullOrEmpty(result["test"].VariationKey));
             Assert.IsFalse(string.IsNullOrEmpty(result["test"].VariationName));

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
@@ -13,6 +13,7 @@ using RichardSzalay.MockHttp;
 using Environment = System.Environment;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using DevCycle.SDK.Server.Common;
 using OpenFeature;
 using OpenFeature.Constant;
@@ -44,7 +45,8 @@ namespace DevCycle.SDK.Server.Local.MSTests
                 new NullLoggerFactory(),
                 localBucketing,
                 restClientOptions: new DevCycleRestClientOptions() { ConfigureMessageHandler = _ => mockHttp });
-            configManager.Initialized = !skipInitialize;
+            if (skipInitialize)
+                configManager.Initialized = !skipInitialize;
 
             DevCycleLocalClient api = new DevCycleLocalClientBuilder()
                 .SetLocalBucketing(localBucketing)
@@ -107,6 +109,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
         public async Task GetFeaturesTest()
         {
             var api = getTestClient();
+            Thread.Sleep(3000);
             var user = new DevCycleUser("j_test");
             user.Country = "CA";
             user.Language = "en";
@@ -161,10 +164,10 @@ namespace DevCycle.SDK.Server.Local.MSTests
         public async Task GetVariableByKeyJsonObjTestAsync()
         {
             using DevCycleLocalClient api = getTestClient(config: Fixtures.ConfigWithJSONValues());
+            Thread.Sleep(5000);
             var user = new DevCycleUser("j_test");
             string key = Fixtures.VariableKey;
-            await Task.Delay(3000);
-
+            
             var expectedValue = Newtonsoft.Json.Linq.JObject.Parse("{\"sample\": \"A\"}");
             var defaultValue = Newtonsoft.Json.Linq.JObject.Parse("{\"key\": \"default\"}");
             var variable = await api.Variable(user, key, defaultValue);
@@ -221,10 +224,10 @@ namespace DevCycle.SDK.Server.Local.MSTests
         public async Task GetVariablesTest()
         {
             using DevCycleLocalClient api = getTestClient();
-
+            
             DevCycleUser user = new DevCycleUser("j_test");
             // Bucketing needs time to work.
-            await Task.Delay(5000);
+            Thread.Sleep(5000);
             var result = await api.AllVariables(user);
 
             Assert.IsTrue(result.ContainsKey("test"));
@@ -340,7 +343,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
             var dvcClient = getTestClient();
             await OpenFeature.Api.Instance.SetProviderAsync(dvcClient.GetOpenFeatureProvider());
             FeatureClient client = OpenFeature.Api.Instance.GetClient();
-
+            Thread.Sleep(5000);
             var ctx = EvaluationContext.Builder().Set("user_id", "j_test").Build();
             var isEnabled = await client.GetBooleanValue("test", false, ctx);
             Assert.IsTrue(isEnabled);

--- a/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
@@ -47,8 +47,8 @@ namespace DevCycle.SDK.Server.Local.MSTests
             var cfgManager = new EnvironmentConfigManager(sdkKey, new DevCycleLocalOptions(),
                 loggerFactory, new LocalBucketing(), restClientOptions: new DevCycleRestClientOptions()
                     { ConfigureMessageHandler = _ => mockHttp },
-                initializedHandler: (isError && !isRetryableError)
-                    ? DidNotInitializeSubscriber
+                initializedHandler: isError
+                    ? isRetryableError ? DidNotInitializeRetryableSubscriber : DidNotInitializeSubscriber
                     : DidInitializeSubscriber);
 
             return new Tuple<EnvironmentConfigManager, MockHttpMessageHandler, MockedRequest>(cfgManager, mockHttp,
@@ -126,6 +126,12 @@ namespace DevCycle.SDK.Server.Local.MSTests
             Assert.AreEqual(0, e.Errors.Count);
         }
 
+        private void DidNotInitializeRetryableSubscriber(object o, DevCycleEventArgs e)
+        {
+            Assert.IsFalse(e.Success);
+            Assert.AreEqual(0, e.Errors.Count);
+        }
+        
         private void DidNotInitializeSubscriber(object o, DevCycleEventArgs e)
         {
             Assert.IsFalse(e.Success);

--- a/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
@@ -87,15 +87,29 @@ namespace DevCycle.SDK.Server.Local.MSTests
         [TestMethod]
         public async Task OnSuccessNotificationTest()
         {
-            var configManager = getTestConfigManager();
-            await configManager.Item1.InitializeConfigAsync();
+            try
+            {
+                var configManager = getTestConfigManager();
+                await configManager.Item1.InitializeConfigAsync();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
         }
 
         [TestMethod]
         public async Task OnErrorNotificationTest()
         {
-            var configManager = getTestConfigManager(true);
-            await configManager.Item1.InitializeConfigAsync();
+            try
+            {
+                var configManager = getTestConfigManager(true);
+                await configManager.Item1.InitializeConfigAsync();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
         }
 
         [TestMethod]

--- a/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/EnvironmentConfigManagerTest.cs
@@ -48,7 +48,7 @@ namespace DevCycle.SDK.Server.Local.MSTests
                 loggerFactory, new LocalBucketing(), restClientOptions: new DevCycleRestClientOptions()
                     { ConfigureMessageHandler = _ => mockHttp },
                 initializedHandler: isError
-                    ? isRetryableError ? DidNotInitializeRetryableSubscriber : DidNotInitializeSubscriber
+                    ? (isRetryableError ? DidNotInitializeRetryableSubscriber : DidNotInitializeSubscriber)
                     : DidInitializeSubscriber);
 
             return new Tuple<EnvironmentConfigManager, MockHttpMessageHandler, MockedRequest>(cfgManager, mockHttp,

--- a/DevCycle.SDK.Server.Local.MSTests/fixtures/config.json
+++ b/DevCycle.SDK.Server.Local.MSTests/fixtures/config.json
@@ -1,13 +1,24 @@
 {
   "project": {
+    "_id": "6216420c2ea68943c8833c09",
+    "key": "default",
+    "a0_organization": "org_NszUFyWBFy7cr95J",
     "settings": {
       "edgeDB": {
         "enabled": false
-      }
-    },
-    "_id": "6216420c2ea68943c8833c09",
-    "key": "default",
-    "a0_organization": "org_NszUFyWBFy7cr95J"
+      },
+      "optIn": {
+        "enabled": false,
+        "colors": {
+
+        }
+      },
+      "obfuscation": {
+        "required": false,
+        "enabled": false
+      },
+      "disablePassthroughRollouts": true
+    }
   },
   "environment": {
     "_id": "6216420c2ea68943c8833c0b",
@@ -42,54 +53,329 @@
           "_id": "6216422850294da359385e90"
         }
       ],
+      "tags": [
+
+      ],
       "configuration": {
         "_id": "621642332ea68943c8833c4a",
         "targets": [
           {
+            "_id": "62742fed1ac522f6bf0ec906",
             "distribution": [
               {
-                "percentage": 0.5,
+                "percentage": 1,
                 "_variation": "6216422850294da359385e8f"
-              },
-              {
-                "percentage": 0.5,
-                "_variation": "6216422850294da359385e90"
               }
             ],
             "_audience": {
-              "_id": "621642332ea68943c8833c4b",
+              "_id": "",
               "filters": {
-                "operator": "and",
                 "filters": [
                   {
-                    "values": [],
-                    "type": "all",
-                    "filters": []
+                    "_audiences": [
+
+                    ],
+                    "values": [
+
+                    ],
+                    "type": "all"
                   }
-                ]
+                ],
+                "operator": "and"
               }
             },
-            "_id": "621642332ea68943c8833c4d"
+            "bucketingKey": "user_id"
           }
-        ],
-        "forcedUsers": {}
+        ]
+      }
+    },
+    {
+      "_id": "62a250840ff6ef4d7f03db23",
+      "key": "june-9-test-1",
+      "type": "release",
+      "variations": [
+        {
+          "variables": [
+            {
+              "_var": "62a250840ff6ef4d7f03db25",
+              "value": true
+            }
+          ],
+          "name": "Variation On",
+          "key": "variation-on",
+          "_id": "62a250840ff6ef4d7f03db29"
+        },
+        {
+          "variables": [
+            {
+              "_var": "62a250840ff6ef4d7f03db25",
+              "value": false
+            }
+          ],
+          "name": "Variation Off",
+          "key": "variation-off",
+          "_id": "62a250840ff6ef4d7f03db2a"
+        }
+      ],
+      "tags": [
+
+      ],
+      "configuration": {
+        "_id": "62a25084c3d808abdafd23bd",
+        "targets": [
+          {
+            "_id": "62d1720e50dfc5077d3a1640",
+            "distribution": [
+              {
+                "percentage": 1,
+                "_variation": "62a250840ff6ef4d7f03db29"
+              }
+            ],
+            "_audience": {
+              "_id": "",
+              "filters": {
+                "filters": [
+                  {
+                    "_audiences": [
+
+                    ],
+                    "values": [
+
+                    ],
+                    "type": "all"
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "bucketingKey": "user_id"
+          }
+        ]
+      }
+    },
+    {
+      "_id": "62df0777cf68087c76427eba",
+      "key": "july-25-release",
+      "type": "release",
+      "variations": [
+        {
+          "variables": [
+            {
+              "_var": "62df0777cf68087c76427ebc",
+              "value": true
+            }
+          ],
+          "name": "Variation On",
+          "key": "variation-on",
+          "_id": "62df0777cf68087c76427ec0"
+        },
+        {
+          "variables": [
+            {
+              "_var": "62df0777cf68087c76427ebc",
+              "value": false
+            }
+          ],
+          "name": "Variation Off",
+          "key": "variation-off",
+          "_id": "62df0777cf68087c76427ec1"
+        }
+      ],
+      "tags": [
+
+      ],
+      "configuration": {
+        "_id": "62df0777cf68087c76427ed5",
+        "targets": [
+          {
+            "_id": "62df19326152fe44e34cbed3",
+            "distribution": [
+              {
+                "percentage": 1,
+                "_variation": "62df0777cf68087c76427ec0"
+              }
+            ],
+            "_audience": {
+              "_id": "",
+              "filters": {
+                "filters": [
+                  {
+                    "_audiences": [
+
+                    ],
+                    "values": [
+
+                    ],
+                    "type": "all"
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "rollout": {
+              "stages": [
+                {
+                  "percentage": 1,
+                  "date": "2022-08-06T22:00:00.000Z",
+                  "type": "linear"
+                }
+              ],
+              "startDate": "2022-07-26T19:30:00.000Z",
+              "startPercentage": 0.01,
+              "type": "gradual"
+            },
+            "bucketingKey": "user_id"
+          },
+          {
+            "_id": "62df19326152fe44e34cbed1",
+            "distribution": [
+              {
+                "percentage": 1,
+                "_variation": "62df0777cf68087c76427ec0"
+              }
+            ],
+            "_audience": {
+              "_id": "",
+              "filters": {
+                "filters": [
+                  {
+                    "_audiences": [
+
+                    ],
+                    "values": [
+                      "1"
+                    ],
+                    "comparator": "=",
+                    "type": "user",
+                    "subType": "user_id"
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "bucketingKey": "user_id"
+          }
+        ]
+      }
+    },
+    {
+      "_id": "62e068c2b8b37c3d367dd2a3",
+      "key": "some-feature-july-26",
+      "type": "release",
+      "variations": [
+        {
+          "variables": [
+            {
+              "_var": "62e068c2b8b37c3d367dd2a5",
+              "value": true
+            },
+            {
+              "_var": "62e069028f88eca7a3ebb7e5",
+              "value": 11
+            }
+          ],
+          "name": "Variation On",
+          "key": "variation-on",
+          "_id": "62e068c2b8b37c3d367dd2a9"
+        },
+        {
+          "variables": [
+            {
+              "_var": "62e068c2b8b37c3d367dd2a5",
+              "value": false
+            },
+            {
+              "_var": "62e069028f88eca7a3ebb7e5",
+              "value": 0
+            }
+          ],
+          "name": "Variation Off",
+          "key": "variation-off",
+          "_id": "62e068c2b8b37c3d367dd2aa"
+        }
+      ],
+      "tags": [
+
+      ],
+      "configuration": {
+        "_id": "62e068c28f88eca7a3ebb7ca",
+        "targets": [
+          {
+            "_id": "62e06903b8b37c3d367dd2f4",
+            "distribution": [
+              {
+                "percentage": 1,
+                "_variation": "62e068c2b8b37c3d367dd2a9"
+              }
+            ],
+            "_audience": {
+              "_id": "",
+              "filters": {
+                "filters": [
+                  {
+                    "_audiences": [
+
+                    ],
+                    "values": [
+
+                    ],
+                    "type": "all"
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "bucketingKey": "user_id"
+          }
+        ]
       }
     }
   ],
   "variables": [
+    {
+      "_id": "62df0777cf68087c76427ebc",
+      "key": "july-25-release",
+      "type": "Boolean"
+    },
+    {
+      "_id": "62a250840ff6ef4d7f03db25",
+      "key": "june-9-test-1",
+      "type": "Boolean"
+    },
+    {
+      "_id": "62e068c2b8b37c3d367dd2a5",
+      "key": "some-feature-july-26",
+      "type": "Boolean"
+    },
+    {
+      "_id": "62e069028f88eca7a3ebb7e5",
+      "key": "some-var",
+      "type": "Number"
+    },
     {
       "_id": "6216422850294da359385e8d",
       "key": "test",
       "type": "Boolean"
     }
   ],
-  "featureVariationMap": {
-    "6216422850294da359385e8b": "6216422850294da359385e8f"
-  },
-  "variableVariationMap": {
-    "test": "6216422850294da359385e8f"
-  },
   "variableHashes": {
+    "july-25-release": 352794632,
+    "june-9-test-1": 1673005043,
+    "some-feature-july-26": 3197965461,
+    "some-var": 3288238772,
     "test": 2447239932
+  },
+  "audiences": {
+
+  },
+  "debugUsers": [
+
+  ],
+  "sse": {
+    "hostname": "https://realtime.ably.io",
+    "path": "/event-stream?key=azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4&v=1.2&channels=dvc_server_89e38dc5596989552d540d44789498711a0cb4f2_v1"
+  },
+  "ably": {
+    "apiKey": "azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4"
   }
 }

--- a/DevCycle.SDK.Server.Local.MSTests/fixtures/config_json_values.json
+++ b/DevCycle.SDK.Server.Local.MSTests/fixtures/config_json_values.json
@@ -91,5 +91,12 @@
   },
   "variableHashes": {
     "test": 2447239932
+  },
+  "sse": {
+    "hostname": "https://realtime.ably.io",
+    "path": "/event-stream?key=azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4&v=1.2&channels=dvc_server_89e38dc5596989552d540d44789498711a0cb4f2_v1"
+  },
+  "ably": {
+    "apiKey": "azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4"
   }
 }

--- a/DevCycle.SDK.Server.Local.MSTests/fixtures/config_special_characters.json
+++ b/DevCycle.SDK.Server.Local.MSTests/fixtures/config_special_characters.json
@@ -95,5 +95,12 @@
   ],
   "variableHashes": {
     "test": 2447239932
+  },
+  "sse": {
+    "hostname": "https://realtime.ably.io",
+    "path": "/event-stream?key=azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4&v=1.2&channels=dvc_server_89e38dc5596989552d540d44789498711a0cb4f2_v1"
+  },
+  "ably": {
+    "apiKey": "azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4"
   }
 }

--- a/DevCycle.SDK.Server.Local.MSTests/fixtures/large_config.json
+++ b/DevCycle.SDK.Server.Local.MSTests/fixtures/large_config.json
@@ -7993,7 +7993,11 @@
       }
     }
   },
+  "sse": {
+    "hostname": "https://realtime.ably.io",
+    "path": "/event-stream?key=azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4&v=1.2&channels=dvc_server_89e38dc5596989552d540d44789498711a0cb4f2_v1"
+  },
   "ably": {
-    "apiKey": "wMFFcfdLbZaiRktb4dX2eCTkAR3Ae8Mw"
+    "apiKey": "azZpGQ.64zbWw:RXCvOj0NO8V5CwpiNhiImhd1n7zsiS0QXgcOWElBxg4"
   }
 }

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -118,8 +118,8 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
 
         private void OnInitialized(DevCycleEventArgs e)
         {
-            Initialized = true;
             e.Success = !(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
+            Initialized = e.Success;
             initializedHandler?.Invoke(this, e);
         }
 

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -118,7 +118,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
 
         private void OnInitialized(DevCycleEventArgs e)
         {
-            Initialized = !(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
+            Initialized = true;
             e.Success = !(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
             initializedHandler?.Invoke(this, e);
         }

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -147,7 +147,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
             if (configEtag != null) request.AddHeader("If-None-Match", configEtag);
             if (configLastModified != null) request.AddHeader("If-Modified-Since", configLastModified);
 
-            RestResponse res = await ClientPolicy.GetInstance().ExponentialBackoffRetryPolicyWithTimeout
+            RestResponse res = await ClientPolicy.GetInstance().RetryOncePolicy
                 .ExecuteAsync(() => restClient.ExecuteAsync(request, cts.Token));
             DevCycleException finalError;
 

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -119,7 +119,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         private void OnInitialized(DevCycleEventArgs e)
         {
             Initialized = true;
-            e.Success = true; //!(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
+            e.Success = !(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
             initializedHandler?.Invoke(this, e);
         }
 

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -118,7 +118,8 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
 
         private void OnInitialized(DevCycleEventArgs e)
         {
-            Initialized = true;
+            Initialized = !(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
+            e.Success = !(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
             initializedHandler?.Invoke(this, e);
         }
 

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -119,7 +119,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         private void OnInitialized(DevCycleEventArgs e)
         {
             Initialized = true;
-            e.Success = !(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
+            e.Success = true; //!(string.IsNullOrEmpty(configLastModified) || string.IsNullOrEmpty(configEtag));
             initializedHandler?.Invoke(this, e);
         }
 


### PR DESCRIPTION
This still maintains the defaulting nature; but updates the initialized event handler args to set success based on the success of initializing the config - not the WASM instance.