### PR TITLE
feat: enable SSE connections by default

### DIFF
--- a/DevCycle.SDK.Server.Common/Model/Local/DevCycleLocalOptions.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/DevCycleLocalOptions.cs
@@ -37,7 +37,11 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         public int EventRequestChunkSize { get; set; }
         
         [JsonProperty("enableBetaRealtimeUpdates")]
+        [Obsolete("EnableBetaRealtimeUpdates is deprecated. SSE connections are now enabled by default.")]
         public bool EnableBetaRealtimeUpdates { get; set; }
+        
+        [JsonProperty("disableRealtimeUpdates")]
+        public bool DisableRealtimeUpdates { get; set; }
         
         [IgnoreDataMember]
         public int FlushEventQueueSize { get; set; }
@@ -73,7 +77,8 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             int maxEventsInQueue = 2000,
             int eventRequestChunkSize = 100,
             int eventFlushIntervalMs = 10 * 1000,
-            bool enableBetaRealtimeUpdates = false
+            bool enableBetaRealtimeUpdates = false,
+            bool disableRealtimeUpdates = false
             )
         {
             ConfigPollingIntervalMs = configPollingIntervalMs;
@@ -86,7 +91,7 @@ namespace DevCycle.SDK.Server.Common.Model.Local
             EventsApiCustomHeaders = eventsApiCustomHeaders;
             DisableAutomaticEvents = disableAutomaticEvents;
             DisableCustomEvents = disableCustomEvents;
-            EnableBetaRealtimeUpdates = enableBetaRealtimeUpdates;
+            DisableRealtimeUpdates = disableRealtimeUpdates;
             
             switch (eventRequestChunkSize)
             {

--- a/DevCycle.SDK.Server.Local.Example/Program.cs
+++ b/DevCycle.SDK.Server.Local.Example/Program.cs
@@ -36,7 +36,7 @@ namespace Example
             }
 
             api = apiBuilder
-                .SetOptions(new DevCycleLocalOptions(enableBetaRealtimeUpdates:true))
+                .SetOptions(new DevCycleLocalOptions())
                 .SetInitializedSubscriber(InitializedEventHandler)
                 .SetRestClientOptions(
                     new DevCycleRestClientOptions()

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -218,13 +218,13 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
                             var sseProp = minimalConfig.RootElement.GetProperty("sse");
                             var sseUri = sseProp.GetProperty("hostname").GetString() +
                                          sseProp.GetProperty("path").GetString();
-                            if (sseManager == null && localOptions.EnableBetaRealtimeUpdates)
+                            if (sseManager == null && !localOptions.DisableRealtimeUpdates)
                             {
                                 sseManager = new SSEManager(sseUri, SSEStateHandler, SSEMessageHandler,
                                     SSEErrorHandler);
                                 sseManager.StartSSE();
                             }
-                            else if (sseManager != null && localOptions.EnableBetaRealtimeUpdates)
+                            else if (sseManager != null && !localOptions.DisableRealtimeUpdates)
                             {
                                 sseManager.RestartSSE(sseUri);
                             }


### PR DESCRIPTION
- SSE connections are now enabled by default, added `DisableRealtimeUpdates` option
- Deprecated `EnableBetaRealtimeUpdates` option


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
