### PR TITLE
chore: add README to nuget package release

### DIFF
--- a/DevCycle.SDK.Server.Cloud/DevCycle.SDK.Server.Cloud.csproj
+++ b/DevCycle.SDK.Server.Cloud/DevCycle.SDK.Server.Cloud.csproj
@@ -27,6 +27,7 @@
     <PackOnBuild>true</PackOnBuild>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -60,6 +61,7 @@
   <ItemGroup>
     <None Remove="NETStandard.Library" />
     <None Remove="Exception\" />
+    <None Include="..\README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
+++ b/DevCycle.SDK.Server.Common/DevCycle.SDK.Server.Common.csproj
@@ -11,6 +11,7 @@
         <FileVersion>3.5.0</FileVersion>
         <Title>DevCycle.SDK.Server.Common</Title>
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,6 +21,7 @@
       <PackageReference Include="Polly" Version="8.5.1" />
       <PackageReference Include="RestSharp" Version="112.0.0" />
       <PackageReference Include="System.Text.Json" Version="8.0.5" />
+      <None Include="..\README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 
 </Project>

--- a/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
+++ b/DevCycle.SDK.Server.Local/DevCycle.SDK.Server.Local.csproj
@@ -30,6 +30,7 @@
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -95,6 +96,7 @@
     <Content Include="..\README.md">
       <Link>README.md</Link>
     </Content>
+    <None Include="..\README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DevCycle.SDK.Server.Common\DevCycle.SDK.Server.Common.csproj" />


### PR DESCRIPTION
## Add README.md to NuGet packages
This PR adds the project README.md file to the DevCycle .NET Server SDK NuGet packages, following the same pattern as implemented in OpenFeature dotnet-sdk PR #164. As recommended by Andre from OpenFeature.

### Changes:
- Added PackageReadmeFile property to SDK project files
- Included README.md in package content with Pack="true" and PackagePath="/"

### Affected packages:
- DevCycle.SDK.Server.Cloud
- DevCycle.SDK.Server.Local
- DevCycle.SDK.Server.Common

### Result:
The README content will now be displayed on the NuGet package pages, providing developers with immediate access to usage documentation and project information when browsing packages.
This follows NuGet best practices for package discoverability and improves the developer experience for anyone finding DevCycle packages on nuget.org.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
