### PR TITLE
feat: added hooks option to initialization

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycleTest.cs
@@ -251,6 +251,50 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
             Assert.AreEqual(TypeEnum.Boolean, result.Type);
             Assert.IsFalse(result.IsDefaulted);
         }
+        
+        [TestMethod]
+        public async Task EvalHooks_PassedInOptions()
+        {
+            const string key = "test";
+            TestEvalHook hook = new TestEvalHook();
+            DevCycleCloudClient api = getTestClient(TestResponse.GetVariableByKeyAsync(key), new DevCycleCloudOptions(false, [hook]));
+            
+            var result = await api.Variable(new DevCycleUser("test"), key, true);
+
+            Assert.AreEqual(1, hook.BeforeCallCount);
+            Assert.AreEqual(1, hook.AfterCallCount); 
+            Assert.AreEqual(0, hook.ErrorCallCount);
+            Assert.AreEqual(1, hook.FinallyCallCount);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(key, result.Key);
+            Assert.AreEqual(true, result.DefaultValue);
+            Assert.AreEqual(TypeEnum.Boolean, result.Type);
+            Assert.IsFalse(result.IsDefaulted);
+        }
+
+        [TestMethod]
+        public async Task EvalHooks_MultipleHooksInOptions()
+        {
+            const string key = "test";
+            TestEvalHook hook1 = new TestEvalHook();
+            TestEvalHook hook2 = new TestEvalHook();
+            
+            TestEvalHook hook = new TestEvalHook();
+            DevCycleCloudClient api = getTestClient(TestResponse.GetVariableByKeyAsync(key), new DevCycleCloudOptions(false, [hook1, hook2]));
+            
+            await Task.Delay(3000);
+            var result = await api.Variable(new DevCycleUser("test"), key, true);
+
+            Assert.AreEqual(1, hook1.BeforeCallCount);
+            Assert.AreEqual(1, hook1.AfterCallCount);
+            Assert.AreEqual(0, hook1.ErrorCallCount);
+            Assert.AreEqual(1, hook1.FinallyCallCount);
+            Assert.AreEqual(1, hook2.BeforeCallCount);
+            Assert.AreEqual(1, hook2.AfterCallCount);
+            Assert.AreEqual(0, hook2.ErrorCallCount);
+            Assert.AreEqual(1, hook2.FinallyCallCount);
+            Assert.IsNotNull(result);
+        }
 
         private void AssertUserDefaultsCorrect(DevCycleUser user)
         {

--- a/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
@@ -45,7 +45,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             logger = loggerFactory.CreateLogger<DevCycleCloudClient>();
             this.options = options != null ? (DevCycleCloudOptions)options : new DevCycleCloudOptions();
             OpenFeatureProvider = new DevCycleProvider(this);
-            evalHooksRunner = new EvalHooksRunner(logger);
+            evalHooksRunner = new EvalHooksRunner(logger, this.options.EvalHooks);
         }
 
         public override string Platform()

--- a/DevCycle.SDK.Server.Common/Model/Cloud/DevCycleCloudOptions.cs
+++ b/DevCycle.SDK.Server.Common/Model/Cloud/DevCycleCloudOptions.cs
@@ -1,12 +1,18 @@
+using System.Collections.Generic;
+
 namespace DevCycle.SDK.Server.Common.Model.Cloud
 {
     public class DevCycleCloudOptions: IDevCycleOptions
     {
         public bool EnableEdgeDB { get; private set; }
+        
+        public List<EvalHook> EvalHooks { get; private set; }
+        
 
-        public DevCycleCloudOptions(bool enableEdgeDB = false)
+        public DevCycleCloudOptions(bool enableEdgeDB = false, List<EvalHook> evalHooks = null)
         {
             EnableEdgeDB = enableEdgeDB;
+            EvalHooks = evalHooks;
         }
     }
 }

--- a/DevCycle.SDK.Server.Common/Model/EvalHooksRunner.cs
+++ b/DevCycle.SDK.Server.Common/Model/EvalHooksRunner.cs
@@ -16,9 +16,9 @@ namespace DevCycle.SDK.Server.Common.Model
         public AfterHookError(string message, System.Exception e) : base(message) { }
     }
 
-    public class EvalHooksRunner(ILogger logger)
+    public class EvalHooksRunner(ILogger logger, List<EvalHook> hooks = null)
     {
-        private readonly List<EvalHook> hooks = [];
+        private readonly List<EvalHook> hooks = hooks ?? [];
 
         public void AddHook(EvalHook hook)
         {
@@ -38,7 +38,7 @@ namespace DevCycle.SDK.Server.Common.Model
         public async Task<HookContext<T>> RunBeforeAsync<T>(List<EvalHook> hooksList, HookContext<T> context, 
             CancellationToken cancellationToken = default)
         {
-            HookContext<T> result = context;
+            var result = context;
             try
             {
                 foreach (var hook in hooksList)

--- a/DevCycle.SDK.Server.Common/Model/Local/DevCycleLocalOptions.cs
+++ b/DevCycle.SDK.Server.Common/Model/Local/DevCycleLocalOptions.cs
@@ -61,6 +61,8 @@ namespace DevCycle.SDK.Server.Common.Model.Local
         [IgnoreDataMember]
         public Dictionary<string, string> EventsApiCustomHeaders { get; set; }
 
+        [IgnoreDataMember]
+        public List<EvalHook> EvalHooks { get; set; }
         
         public DevCycleLocalOptions(
             int configPollingIntervalMs = 1000,

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
@@ -535,5 +535,56 @@ namespace DevCycle.SDK.Server.Local.MSTests
             Assert.AreEqual(0, hook2.FinallyCallCount);
             Assert.IsNotNull(result);
         }
+
+        [TestMethod]
+        public async Task EvalHooks_PassedInOptions()
+        {
+            const string key = "test";
+            TestEvalHook hook = new TestEvalHook();
+            var options = new DevCycleLocalOptions
+            {
+                EvalHooks = [hook]
+            };
+            using DevCycleLocalClient api = getTestClient(options);
+            
+            await Task.Delay(3000);
+            var result = await api.VariableAsync(new DevCycleUser("test"), key, true);
+
+            Assert.AreEqual(1, hook.BeforeCallCount);
+            Assert.AreEqual(1, hook.AfterCallCount); 
+            Assert.AreEqual(0, hook.ErrorCallCount);
+            Assert.AreEqual(1, hook.FinallyCallCount);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(key, result.Key);
+            Assert.AreEqual(true, result.DefaultValue);
+            Assert.AreEqual(TypeEnum.Boolean, result.Type);
+            Assert.IsFalse(result.IsDefaulted);
+        }
+
+        [TestMethod]
+        public async Task EvalHooks_MultipleHooksInOptions()
+        {
+            const string key = "test";
+            TestEvalHook hook1 = new TestEvalHook();
+            TestEvalHook hook2 = new TestEvalHook();
+            var options = new DevCycleLocalOptions
+            {
+                EvalHooks = [hook1, hook2]
+            };
+            using DevCycleLocalClient api = getTestClient(options);
+            
+            await Task.Delay(3000);
+            var result = await api.VariableAsync(new DevCycleUser("test"), key, true);
+
+            Assert.AreEqual(1, hook1.BeforeCallCount);
+            Assert.AreEqual(1, hook1.AfterCallCount);
+            Assert.AreEqual(0, hook1.ErrorCallCount);
+            Assert.AreEqual(1, hook1.FinallyCallCount);
+            Assert.AreEqual(1, hook2.BeforeCallCount);
+            Assert.AreEqual(1, hook2.AfterCallCount);
+            Assert.AreEqual(0, hook2.ErrorCallCount);
+            Assert.AreEqual(1, hook2.FinallyCallCount);
+            Assert.IsNotNull(result);
+        }
     }
 }

--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -97,7 +97,7 @@ namespace DevCycle.SDK.Server.Local.Api
             this.configManager.SetEventQueue(eventQueue);
             var platformData = new PlatformData();
             localBucketing.SetPlatformData(platformData.ToJson());
-            evalHooksRunner = new EvalHooksRunner(logger);
+            evalHooksRunner = new EvalHooksRunner(logger, dvcLocalOptions.EvalHooks);
 
             if(dvcLocalOptions.CdnSlug != "")
             {


### PR DESCRIPTION
# Changes

- added option to pass in hooks when initializing

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
