### PR TITLE
chore: remove test-harness override capabilities

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -13,4 +13,3 @@ jobs:
         with:
           sdks-to-test: dotnet
           sdk-github-sha: ${{github.event.pull_request.head.sha}}
-          sdk-capabilities: '["cloud", "local","edgeDB", "clientCustomData","v2Config", "allFeatures", "allVariables", "evalReason", "cloudEvalReason", "eventsEvalReason"]'


### PR DESCRIPTION
running test-harness with default capabilities now that they are updated after release

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->
