### PR TITLE
feat: add variable metadata to the after and finally hooks

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/TestEvalHook.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/TestEvalHook.cs
@@ -47,14 +47,14 @@ public class TestEvalHook : EvalHook
                 await base.ErrorAsync(context, error, cancellationToken);
             }
 
-            public override async Task FinallyAsync<T>(HookContext<T> context, Variable<T> evaluationDetails,VariableMetadata variableMetadata,  CancellationToken cancellationToken = default)
+            public override async Task FinallyAsync<T>(HookContext<T> context, Variable<T> evaluationDetails, VariableMetadata variableMetadata,  CancellationToken cancellationToken = default)
             {
                 FinallyCallCount++;
                 if (ThrowFinally)
                 {
                     throw new Exception("Finally hook error");
                 }
-                await base.FinallyAsync(context, evaluationDetails,variableMetadata, cancellationToken);
+                await base.FinallyAsync(context, evaluationDetails, variableMetadata, cancellationToken);
             }
         }
 }

--- a/DevCycle.SDK.Server.Cloud.MSTests/TestEvalHook.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/TestEvalHook.cs
@@ -27,14 +27,14 @@ public class TestEvalHook : EvalHook
                 return await base.BeforeAsync(context, cancellationToken);
             }
 
-            public override async Task AfterAsync<T>(HookContext<T> context, Variable<T> details, CancellationToken cancellationToken = default)
+            public override async Task AfterAsync<T>(HookContext<T> context, Variable<T> details, VariableMetadata variableMetadata, CancellationToken cancellationToken = default)
             {
                 AfterCallCount++;
                 if (ThrowAfter)
                 {
                     throw new Exception("After hook error");
                 }
-                await base.AfterAsync(context, details, cancellationToken);
+                await base.AfterAsync(context, details, variableMetadata, cancellationToken);
             }
 
             public override async Task ErrorAsync<T>(HookContext<T> context, Exception error, CancellationToken cancellationToken = default)
@@ -47,14 +47,14 @@ public class TestEvalHook : EvalHook
                 await base.ErrorAsync(context, error, cancellationToken);
             }
 
-            public override async Task FinallyAsync<T>(HookContext<T> context, Variable<T> evaluationDetails, CancellationToken cancellationToken = default)
+            public override async Task FinallyAsync<T>(HookContext<T> context, Variable<T> evaluationDetails,VariableMetadata variableMetadata,  CancellationToken cancellationToken = default)
             {
                 FinallyCallCount++;
                 if (ThrowFinally)
                 {
                     throw new Exception("Finally hook error");
                 }
-                await base.FinallyAsync(context, evaluationDetails, cancellationToken);
+                await base.FinallyAsync(context, evaluationDetails,variableMetadata, cancellationToken);
             }
         }
 }

--- a/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
@@ -156,7 +156,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
                 {
                     throw beforeHookError;
                 }
-                await evalHooksRunner.RunAfterAsync(reversedHooks, hookContext, variable);
+                await evalHooksRunner.RunAfterAsync(reversedHooks, hookContext, variable, null);
             }
             catch (Exception e)
             {
@@ -178,7 +178,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             }
             finally
             {
-                await evalHooksRunner.RunFinallyAsync(reversedHooks, hookContext, variable);
+                await evalHooksRunner.RunFinallyAsync(reversedHooks, hookContext, variable, null);
             }
 
             return variable;

--- a/DevCycle.SDK.Server.Common/Model/EvalHook.cs
+++ b/DevCycle.SDK.Server.Common/Model/EvalHook.cs
@@ -11,7 +11,7 @@ namespace DevCycle.SDK.Server.Common.Model
         }
 
         public virtual Task AfterAsync<T>(HookContext<T> context,
-            Variable<T> details,
+            Variable<T> details, VariableMetadata variableMetadata,
             CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
@@ -25,7 +25,7 @@ namespace DevCycle.SDK.Server.Common.Model
         }
 
         public virtual Task FinallyAsync<T>(HookContext<T> context,
-            Variable<T> evaluationDetails,
+            Variable<T> evaluationDetails,  VariableMetadata variableMetadata,
             CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;

--- a/DevCycle.SDK.Server.Common/Model/EvalHooksRunner.cs
+++ b/DevCycle.SDK.Server.Common/Model/EvalHooksRunner.cs
@@ -54,14 +54,14 @@ namespace DevCycle.SDK.Server.Common.Model
         }
 
         public async Task RunAfterAsync<T>(List<EvalHook> hooksList, HookContext<T> context,
-            Variable<T> details,
+            Variable<T> details, VariableMetadata variableMetadata,
             CancellationToken cancellationToken = default)
         {
             try
             {
                 foreach (var hook in hooksList)
                 {
-                    await hook.AfterAsync(context, details, cancellationToken);
+                    await hook.AfterAsync(context, details, variableMetadata, cancellationToken);
                 }
             } catch (System.Exception e)    
             {
@@ -86,14 +86,14 @@ namespace DevCycle.SDK.Server.Common.Model
         }
 
         public async Task RunFinallyAsync<T>(List<EvalHook> hooksList, HookContext<T> context,
-            Variable<T> evaluationDetails,
+            Variable<T> evaluationDetails, VariableMetadata variableMetadata,
             CancellationToken cancellationToken = default)
         {
             try
             {
                 foreach (var hook in hooksList)
                 {
-                    await hook.FinallyAsync(context, evaluationDetails, cancellationToken);
+                    await hook.FinallyAsync(context, evaluationDetails, variableMetadata, cancellationToken);
                 }
             } catch (System.Exception e)
             {

--- a/DevCycle.SDK.Server.Common/Model/VariableMetadata.cs
+++ b/DevCycle.SDK.Server.Common/Model/VariableMetadata.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace DevCycle.SDK.Server.Common.Model
+{
+    [DataContract]
+    public class VariableMetadata
+    {
+        [DataMember(Name = "FeatureId", EmitDefaultValue = false)]
+        [JsonProperty("featureId")]
+        public string FeatureId { get; set; }
+    }
+
+}

--- a/DevCycle.SDK.Server.Local.Example/Program.cs
+++ b/DevCycle.SDK.Server.Local.Example/Program.cs
@@ -70,6 +70,12 @@ namespace Example
             {
                 Console.WriteLine(entry.Key + " : " + entry.Value);
             }
+            var resultVar = await api.AllVariables(user);
+
+            foreach (var entry in resultVar)
+            {
+                Console.WriteLine(entry.Key + " : " + entry.Value);
+            }
 
             Console.WriteLine((await api.Variable(user, "example-text", "")).Value.ToString());
             Console.WriteLine(await api.AllVariables(user));
@@ -126,7 +132,7 @@ namespace Example
             }
             Console.WriteLine(api.GetConfigMetadata().ToString());
             
-            var variable = await api.VariableAsync(user, "exmaple-text", "default");
+            var variable = await api.VariableAsync(user, "example-text", "default");
             Console.WriteLine(variable);
             
             // End openfeature example
@@ -143,11 +149,12 @@ namespace Example
             return await base.BeforeAsync(context, cancellationToken);
         }
 
-        public override async Task AfterAsync<T>(DevCycle.SDK.Server.Common.Model.HookContext<T> context, Variable<T> details, CancellationToken cancellationToken = default)
+        public override async Task AfterAsync<T>(DevCycle.SDK.Server.Common.Model.HookContext<T> context, Variable<T> details, VariableMetadata variableMetadata, CancellationToken cancellationToken = default)
         {
             Console.WriteLine("AfterAsync");
             Console.WriteLine(context.Metadata.Project.Key);
-            await base.AfterAsync(context, details, cancellationToken);
+            Console.WriteLine(variableMetadata.FeatureId);
+            await base.AfterAsync(context, details, variableMetadata, cancellationToken);
         }
 
         public override async Task ErrorAsync<T>(DevCycle.SDK.Server.Common.Model.HookContext<T> context, Exception error, CancellationToken cancellationToken = default)
@@ -157,11 +164,12 @@ namespace Example
             await base.ErrorAsync(context, error, cancellationToken);
         }
 
-        public override async Task FinallyAsync<T>(DevCycle.SDK.Server.Common.Model.HookContext<T> context, Variable<T> evaluationDetails, CancellationToken cancellationToken = default)
+        public override async Task FinallyAsync<T>(DevCycle.SDK.Server.Common.Model.HookContext<T> context, Variable<T> evaluationDetails, VariableMetadata variableMetadata,  CancellationToken cancellationToken = default)
         {
             Console.WriteLine("FinallyAsync");
             Console.WriteLine(context.Metadata.Environment.Id);
-            await base.FinallyAsync(context, evaluationDetails, cancellationToken);
+            Console.WriteLine(variableMetadata.FeatureId);
+            await base.FinallyAsync(context, evaluationDetails, variableMetadata, cancellationToken);
         }   
     }
 }


### PR DESCRIPTION
- add feature id as part of variable metadata for after and finally hooks
- test using the local example app

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
