### PR TITLE
fix: remove duplicate RunFinallyAsync hook call

### DIFF
--- a/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
@@ -527,6 +527,28 @@ namespace DevCycle.SDK.Server.Local.MSTests
         }
 
         [TestMethod]
+        public async Task EvalHooks_Defaulted()
+        {
+            const string key = "should-default";
+            using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
+            TestEvalHook hook = new TestEvalHook();
+            api.AddEvalHook(hook);
+
+            await Task.Delay(3000);
+            var result = await api.VariableAsync(new DevCycleUser("test"), key, true);
+
+            Assert.IsTrue(result.IsDefaulted);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(key, result.Key);
+            Assert.AreEqual(true, result.DefaultValue);
+            Assert.AreEqual(TypeEnum.Boolean, result.Type);
+            Assert.AreEqual(1, hook.BeforeCallCount);
+            Assert.AreEqual(1, hook.AfterCallCount);
+            Assert.AreEqual(0, hook.ErrorCallCount);
+            Assert.AreEqual(1, hook.FinallyCallCount);
+        }
+
+        [TestMethod]
         public async Task ClearEvalHooks_RemovesAllHooks()
         {
             const string key = "test";

--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -127,7 +127,7 @@ namespace DevCycle.SDK.Server.Local.Api
         }
 
         public ConfigMetadata GetConfigMetadata()
-        { 
+        {
             return configManager.GetConfigMetadata();
         }
 
@@ -399,7 +399,7 @@ namespace DevCycle.SDK.Server.Local.Api
             VariableMetadata variableMetadata = new VariableMetadata();
 
             Variable<T> existingVariable = Common.Model.Variable<T>.InitializeFromVariable(null, key, defaultValue); ;
-            HookContext<T> hookContext = new HookContext<T>(user, key, defaultValue, null, configMetadata );
+            HookContext<T> hookContext = new HookContext<T>(user, key, defaultValue, null, configMetadata);
 
             var hooks = evalHooksRunner.GetHooks();
             var reversedHooks = new List<EvalHook>(hooks);
@@ -426,7 +426,6 @@ namespace DevCycle.SDK.Server.Local.Api
                     logger.LogWarning("Variable data is null, using default value");
                     existingVariable.Eval = new EvalReason(EvalReasons.DEFAULT, DefaultReasonDetails.UserNotTargeted);
                     await evalHooksRunner.RunAfterAsync(reversedHooks, hookContext, existingVariable, variableMetadata);
-                    await evalHooksRunner.RunFinallyAsync(reversedHooks, hookContext, existingVariable, variableMetadata);
                     return existingVariable;
                 }
 


### PR DESCRIPTION
when variable defaults, the finally hook is run twice since its called explicitly and also in the finally block.

- remove explicit call to finally hook
- add test for defaulted variable