### PR TITLE
fix: Always reconnect an SSE connection on an error

### DIFF
--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -285,7 +285,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         private void SSEErrorHandler(object sender, ExceptionEventArgs args)
         {
             logger.LogWarning(args.Exception, "SSE Connection Returned an error");
-            sseManager.RestartSSE(resetBackoffDelay: false);
+            sseManager?.RestartSSE(resetBackoffDelay: false);
         }
 
         private void SSEStateHandler(object sender, StateChangedEventArgs args)

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -45,7 +45,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         public virtual string Config { get; private set; }
         public virtual bool Initialized { get; internal set; }
         
-        private const int ssePollingIntervalMs = 15 * 60 * 60 * 1000;
+        private const int ssePollingIntervalMs = 15 * 60 * 1000;
 
         public EnvironmentConfigManager(
             string sdkKey,
@@ -277,6 +277,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         private void SSEErrorHandler(object sender, ExceptionEventArgs args)
         {
             logger.LogWarning(args.Exception, "SSE Connection Returned an error");
+            sseManager.RestartSSE();
         }
 
         private void SSEStateHandler(object sender, StateChangedEventArgs args)
@@ -296,6 +297,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
                 case ReadyState.Shutdown:
                     logger.LogInformation("SSE Shutdown");
                     pollingTimer = new Timer(FetchConfigAsync, null, pollingIntervalMs, pollingIntervalMs);
+                    sseManager.RestartSSE();
                     break;
             }
         }

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -259,7 +259,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
                     catch (Exception e)
                     {
                         // This is to catch any exception that is thrown by the SetConfig method if the config is not valid
-                        logger.LogError(e, "Failed to set config: {EMessage} {InnerExceptionMessage}", e.Message, e.InnerException.Message);
+                        logger.LogError(e, "Failed to set config: {EMessage} {InnerExceptionMessage}", e.Message, e.InnerException?.Message);
                     }
 
                     break;

--- a/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/EnvironmentConfigManager.cs
@@ -285,7 +285,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         private void SSEErrorHandler(object sender, ExceptionEventArgs args)
         {
             logger.LogWarning(args.Exception, "SSE Connection Returned an error");
-            sseManager.RestartSSE();
+            sseManager.RestartSSE(resetBackoffDelay: false);
         }
 
         private void SSEStateHandler(object sender, StateChangedEventArgs args)
@@ -293,7 +293,6 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
             switch (args.ReadyState)
             {
                 case ReadyState.Raw:
-                    break;
                 case ReadyState.Connecting:
                     break;
                 case ReadyState.Open:

--- a/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
@@ -4,21 +4,18 @@ using LaunchDarkly.EventSource;
 
 namespace DevCycle.SDK.Server.Local.ConfigManager
 {
-    public class SSEManager
+    public class SSEManager : IDisposable
     {
         private EventSource sseClient { get; set; }
         private string sseUri { get; set; }
-        private EventHandler<StateChangedEventArgs> stateHandler { get; set; }
-        private EventHandler<MessageReceivedEventArgs> messageHandler { get; set; }
-        private EventHandler<ExceptionEventArgs> errorHandler { get; set; }
-        
-        
-        
+        private EventHandler<StateChangedEventArgs> stateHandler { get; }
+        private EventHandler<MessageReceivedEventArgs> messageHandler { get; }
+        private EventHandler<ExceptionEventArgs> errorHandler { get; }
         
         public SSEManager(string sseUri, EventHandler<StateChangedEventArgs> stateHandler,
             EventHandler<MessageReceivedEventArgs> messageHandler, EventHandler<ExceptionEventArgs> errorHandler)
         {
-            var sseConfig = Configuration.Builder(new Uri(sseUri)).InitialRetryDelay(TimeSpan.FromSeconds(1)).Build();
+            var sseConfig = Configuration.Builder(new Uri(sseUri)).InitialRetryDelay(TimeSpan.FromSeconds(10)).Build();
             sseClient = new EventSource(sseConfig);
             this.sseUri = sseUri;
             this.stateHandler = stateHandler;
@@ -56,10 +53,9 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
             }
         }
 
-        public void CloseSSE()
+        public void Dispose()
         {
             sseClient.Close();
         }
-
     }
 }

--- a/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
@@ -13,10 +13,12 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
         private EventHandler<ExceptionEventArgs> errorHandler { get; set; }
         
         
+        
+        
         public SSEManager(string sseUri, EventHandler<StateChangedEventArgs> stateHandler,
             EventHandler<MessageReceivedEventArgs> messageHandler, EventHandler<ExceptionEventArgs> errorHandler)
         {
-            var sseConfig = Configuration.Builder(new Uri(sseUri)).InitialRetryDelay(new TimeSpan(0, 0, 10)).Build();
+            var sseConfig = Configuration.Builder(new Uri(sseUri)).InitialRetryDelay(TimeSpan.FromSeconds(1)).Build();
             sseClient = new EventSource(sseConfig);
             this.sseUri = sseUri;
             this.stateHandler = stateHandler;
@@ -41,7 +43,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
                 sseClient.Close();
                 
                 sseClient = new EventSource(Configuration.Builder(new Uri(uri))
-                    .InitialRetryDelay(new TimeSpan(0, 0, 10)).Build());
+                    .InitialRetryDelay(TimeSpan.FromSeconds(1)).Build());
                 sseClient.MessageReceived += messageHandler;
                 sseClient.Error += errorHandler;
                 sseClient.Closed += stateHandler;

--- a/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
@@ -55,7 +55,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
 
         public void Dispose()
         {
-            sseClient.Close();
+            sseClient?.Close();
         }
     }
 }

--- a/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
@@ -40,7 +40,7 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
                 sseClient.Close();
                 
                 sseClient = new EventSource(Configuration.Builder(new Uri(uri))
-                    .InitialRetryDelay(TimeSpan.FromSeconds(1)).Build());
+                    .InitialRetryDelay(TimeSpan.FromSeconds(10)).Build());
                 sseClient.MessageReceived += messageHandler;
                 sseClient.Error += errorHandler;
                 sseClient.Closed += stateHandler;

--- a/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
+++ b/DevCycle.SDK.Server.Local/ConfigManager/SSEManager.cs
@@ -55,7 +55,34 @@ namespace DevCycle.SDK.Server.Local.ConfigManager
 
         public void Dispose()
         {
-            sseClient?.Close();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (sseClient != null)
+                {
+                    // Unsubscribe event handlers
+                    sseClient.Closed -= stateHandler;
+                    sseClient.Opened -= stateHandler;
+                    sseClient.Error -= errorHandler;
+                    sseClient.MessageReceived -= messageHandler;
+
+                    // Dispose or Close sseClient
+                    if (sseClient is IDisposable disposable)
+                    {
+                        disposable.Dispose();
+                    }
+                    else
+                    {
+                        sseClient.Close();
+                    }
+                    sseClient = null;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
SSE connection errors in rare cases may not always trigger an error state that can then be caught by the closed state - this ensures that errors will reconnect - but ensure that the backoff delay is kept intact in case this is a repeated error.