### PR TITLE
fix: Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -1,4 +1,6 @@
 name: Run Test Harness
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/dotnet-server-sdk/security/code-scanning/14](https://github.com/DevCycleHQ/dotnet-server-sdk/security/code-scanning/14)

To fix this issue, an explicit `permissions` block must be added to the workflow or to the job, limiting the permissions granted to the `GITHUB_TOKEN` to the minimum required. Based on the provided workflow—which runs test harnesses and does not appear to require write access to repository contents, issues, pull requests, etc.—the minimal permissions should be `contents: read`. This can be set at the top level (so it applies to every job unless overridden) for maximum clarity and safety. The change should go at the same level as `name` and `on` (near the top of the file). No additional imports or dependencies are required. Only the `.github/workflows/run-test-harness.yml` file needs an update, by adding a `permissions:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
