### PR TITLE
fix: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/dotnet-server-sdk/security/code-scanning/4](https://github.com/DevCycleHQ/dotnet-server-sdk/security/code-scanning/4)

To fix the problem, you should add a minimal `permissions` block to the workflow YAML file, limiting the GITHUB_TOKEN scope to only what is needed. For this workflow, only read access to repository contents is required, so the block should be:
```yaml
permissions:
  contents: read
```
The block should be added at the top level of the workflow YAML file (after the `name:` and before `on:`), which applies to all jobs. No additional methods, imports, or changes are needed beyond this YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
