### PR TITLE
fix: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -1,5 +1,8 @@
 name: Test Run Examples
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/dotnet-server-sdk/security/code-scanning/3](https://github.com/DevCycleHQ/dotnet-server-sdk/security/code-scanning/3)

To resolve the issue, add an explicit `permissions:` block at the workflow root level (above or below `env:` but before `jobs:`) to restrict the GITHUB_TOKEN permissions. Since the steps shown (`actions/checkout`, `setup-dotnet`, build/run commands) do not require write access to repository resources, specifying `contents: read` is sufficient and adheres to the principle of least privilege. Edit `.github/workflows/test-run-examples.yml` accordingly. No further imports or code definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
