### PR TITLE
fix: validate non-empty flag key in Variable<T>

### DIFF
--- a/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
@@ -103,11 +103,6 @@ namespace DevCycle.SDK.Server.Cloud.Api
                 throw new ArgumentException("key cannot be null or empty");
             }
 
-            if (defaultValue == null)
-            {
-                throw new ArgumentNullException(nameof(defaultValue));
-            }
-
             AddDefaults(user);
 
             string lowerKey = key.ToLower();

--- a/DevCycle.SDK.Server.Common/Model/Variable.cs
+++ b/DevCycle.SDK.Server.Common/Model/Variable.cs
@@ -129,7 +129,9 @@ namespace DevCycle.SDK.Server.Common.Model
 
             try
             {
-                var baseType = variableValue.GetType();
+                // A null default value is legitimate for JSON variables (and nullable strings),
+                // so fall back to the declared type rather than dereferencing the value.
+                var baseType = variableValue?.GetType() ?? typeof(T);
 
                 if (baseType == typeof(string))
                 {

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Local.Api;
 using DevCycle.SDK.Server.Common.Model;
@@ -231,6 +231,57 @@ namespace DevCycle.SDK.Server.Local.MSTests
 
                 var variable = api.Variable(null, "some_key", true).Result;
             });
+        }
+
+        [TestMethod]
+        public void Variable_NullKey_ThrowsArgumentException()
+        {
+            // Reaching the WASM bucketing engine with a null/empty flag key
+            // triggers an internal abort() and corrupts the WASM heap. Match
+            // the Java/Python SDKs (and Cloud client) by failing fast with a
+            // clear ArgumentException before we ever enter WASM.
+            using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
+            var user = new DevCycleUser("test_user");
+
+            Assert.Throws<ArgumentException>(() => api.Variable(user, null, true).Result);
+        }
+
+        [TestMethod]
+        public void Variable_EmptyKey_ThrowsArgumentException()
+        {
+            using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
+            var user = new DevCycleUser("test_user");
+
+            Assert.Throws<ArgumentException>(() => api.Variable(user, "", true).Result);
+        }
+
+        [TestMethod]
+        public async Task VariableAsync_NullKey_ThrowsArgumentException()
+        {
+            using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
+            var user = new DevCycleUser("test_user");
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
+                await api.VariableAsync(user, null, true));
+        }
+
+        [TestMethod]
+        public async Task VariableAsync_EmptyKey_ThrowsArgumentException()
+        {
+            using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
+            var user = new DevCycleUser("test_user");
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
+                await api.VariableAsync(user, "", true));
+        }
+
+        [TestMethod]
+        public void Variable_NullDefaultValue_ThrowsArgumentNullException()
+        {
+            using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
+            var user = new DevCycleUser("test_user");
+
+            Assert.Throws<ArgumentNullException>(() => api.Variable<string>(user, "some_key", null).Result);
         }
 
         [TestMethod]

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
@@ -285,6 +285,16 @@ namespace DevCycle.SDK.Server.Local.MSTests
         }
 
         [TestMethod]
+        public async Task VariableAsync_NullDefaultValue_ThrowsArgumentNullException()
+        {
+            using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
+            var user = new DevCycleUser("test_user");
+
+            await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+                await api.VariableAsync<string>(user, "some_key", null));
+        }
+
+        [TestMethod]
         public void User_NullUserId_ThrowsException()
         {
             Assert.Throws<ArgumentException>(() => { _ = new DevCycleUser(); });

--- a/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
+++ b/DevCycle.SDK.Server.Local.MSTests/DevCycleTest.cs
@@ -4,6 +4,7 @@ using DevCycle.SDK.Server.Local.Api;
 using DevCycle.SDK.Server.Common.Model;
 using DevCycle.SDK.Server.Common.Model.Local;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 using Environment = System.Environment;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -276,22 +277,27 @@ namespace DevCycle.SDK.Server.Local.MSTests
         }
 
         [TestMethod]
-        public void Variable_NullDefaultValue_ThrowsArgumentNullException()
+        public async Task Variable_NullJsonDefaultValue_IsAllowed()
         {
+            // A null default is legitimate for JSON variables, so the key validation
+            // above must not be extended to defaultValue.
             using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
             var user = new DevCycleUser("test_user");
 
-            Assert.Throws<ArgumentNullException>(() => api.Variable<string>(user, "some_key", null).Result);
+            var variable = await api.Variable<JObject>(user, "some_key", null);
+
+            Assert.IsNotNull(variable);
         }
 
         [TestMethod]
-        public async Task VariableAsync_NullDefaultValue_ThrowsArgumentNullException()
+        public async Task VariableAsync_NullJsonDefaultValue_IsAllowed()
         {
             using DevCycleLocalClient api = DevCycleTestClient.getTestClient();
             var user = new DevCycleUser("test_user");
 
-            await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
-                await api.VariableAsync<string>(user, "some_key", null));
+            var variable = await api.VariableAsync<JObject>(user, "some_key", null);
+
+            Assert.IsNotNull(variable);
         }
 
         [TestMethod]

--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -307,6 +307,16 @@ namespace DevCycle.SDK.Server.Local.Api
         {
             var requestUser = new DevCyclePopulatedUser(user);
 
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException("key cannot be null or empty");
+            }
+
+            if (defaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(defaultValue));
+            }
+
             if (!configManager.Initialized)
             {
                 logger.LogWarning("Variable called before DevCycleClient has initialized, returning default value");
@@ -365,6 +375,16 @@ namespace DevCycle.SDK.Server.Local.Api
         public async Task<Variable<T>> VariableAsync<T>(DevCycleUser user, string key, T defaultValue)
         {
             var requestUser = new DevCyclePopulatedUser(user);
+
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException("key cannot be null or empty");
+            }
+
+            if (defaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(defaultValue));
+            }
 
             if (!configManager.Initialized)
             {

--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -335,11 +335,6 @@ namespace DevCycle.SDK.Server.Local.Api
                 throw new ArgumentException("key cannot be null or empty");
             }
 
-            if (defaultValue == null)
-            {
-                throw new ArgumentNullException(nameof(defaultValue));
-            }
-
             if (!configManager.Initialized)
             {
                 logger.LogWarning("Variable called before DevCycleClient has initialized, returning default value");
@@ -402,11 +397,6 @@ namespace DevCycle.SDK.Server.Local.Api
             if (string.IsNullOrEmpty(key))
             {
                 throw new ArgumentException("key cannot be null or empty");
-            }
-
-            if (defaultValue == null)
-            {
-                throw new ArgumentNullException(nameof(defaultValue));
             }
 
             if (!configManager.Initialized)

--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -330,6 +330,16 @@ namespace DevCycle.SDK.Server.Local.Api
         {
             var requestUser = new DevCyclePopulatedUser(user);
 
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException("key cannot be null or empty");
+            }
+
+            if (defaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(defaultValue));
+            }
+
             if (!configManager.Initialized)
             {
                 logger.LogWarning("Variable called before DevCycleClient has initialized, returning default value");
@@ -388,6 +398,16 @@ namespace DevCycle.SDK.Server.Local.Api
         public async Task<Variable<T>> VariableAsync<T>(DevCycleUser user, string key, T defaultValue)
         {
             var requestUser = new DevCyclePopulatedUser(user);
+
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException("key cannot be null or empty");
+            }
+
+            if (defaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(defaultValue));
+            }
 
             if (!configManager.Initialized)
             {


### PR DESCRIPTION
## Summary

Validates `key` in Local `Variable<T>` and `VariableAsync<T>`, throwing `ArgumentException` for null or empty keys.

## Motivation

Invalid keys can reach the WASM bucketing engine and trigger AssemblyScript aborts. Repeated failures can corrupt WASM heap state and eventually cause Wasmtime runtime failures. Failing fast at the SDK boundary prevents this path and gives callers a clear exception.

## Null defaultValue

Null is valid input for JSON variables, so this also removes the `defaultValue` null check from `DevCycleCloudClient`, where it already existed. `Variable<T>.DetermineType` called `variableValue.GetType()`, which threw `NullReferenceException` on a null default; it now falls back to `typeof(T)`.
