### PR TITLE
fix: prevent async void Track from crashing the host process

### DIFF
--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
@@ -22,7 +22,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
         private static readonly TimeSpan LogWaitTimeout = TimeSpan.FromSeconds(5);
 
         [TestMethod]
-        public void Track_WhenClientTrackThrows_DoesNotThrowAndLogsError()
+        public void Track_WhenClientTrackThrows_DoesNotThrowAndLogsWarning()
         {
             var logger = new CapturingLogger();
             var client = new ThrowingTrackClient(new InvalidOperationException("track boom"));
@@ -32,14 +32,14 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
 
             provider.Track("my-event", context, TrackingEventDetails.Empty);
 
-            var entry = WaitForError(logger);
-            Assert.IsNotNull(entry, "expected a logged error for the failed tracking call");
+            var entry = WaitForWarning(logger);
+            Assert.IsNotNull(entry, "expected a logged warning for the failed tracking call");
             StringAssert.Contains(entry.Message, "my-event");
             Assert.IsInstanceOfType(entry.Exception, typeof(InvalidOperationException));
         }
 
         [TestMethod]
-        public void Track_WithNullEvaluationContext_DoesNotThrowAndLogsError()
+        public void Track_WithNullEvaluationContext_DoesNotThrowAndLogsWarning()
         {
             var logger = new CapturingLogger();
             var client = new RecordingTrackClient();
@@ -47,13 +47,13 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
 
             provider.Track("my-event", null, TrackingEventDetails.Empty);
 
-            var entry = WaitForError(logger);
-            Assert.IsNotNull(entry, "expected a logged error for the null evaluation context");
+            var entry = WaitForWarning(logger);
+            Assert.IsNotNull(entry, "expected a logged warning for the null evaluation context");
             Assert.AreEqual(0, client.CallCount, "client should not be called when context conversion fails");
         }
 
         [TestMethod]
-        public void Track_WithContextMissingTargetingKey_DoesNotThrowAndLogsError()
+        public void Track_WithContextMissingTargetingKey_DoesNotThrowAndLogsWarning()
         {
             var logger = new CapturingLogger();
             var client = new RecordingTrackClient();
@@ -63,13 +63,13 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
 
             provider.Track("my-event", context, TrackingEventDetails.Empty);
 
-            var entry = WaitForError(logger);
-            Assert.IsNotNull(entry, "expected a logged error for the missing targeting key");
+            var entry = WaitForWarning(logger);
+            Assert.IsNotNull(entry, "expected a logged warning for the missing targeting key");
             Assert.AreEqual(0, client.CallCount, "client should not be called when context conversion fails");
         }
 
         [TestMethod]
-        public void Track_WithNullTrackingEventDetails_DoesNotThrowAndLogsError()
+        public void Track_WithNullTrackingEventDetails_DoesNotThrowAndLogsWarning()
         {
             var logger = new CapturingLogger();
             var client = new RecordingTrackClient();
@@ -79,8 +79,8 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
 
             provider.Track("my-event", context, null);
 
-            var entry = WaitForError(logger);
-            Assert.IsNotNull(entry, "expected a logged error for the null tracking event details");
+            var entry = WaitForWarning(logger);
+            Assert.IsNotNull(entry, "expected a logged warning for the null tracking event details");
             Assert.AreEqual(0, client.CallCount, "client should not be called when event conversion fails");
         }
 
@@ -113,13 +113,13 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
             Assert.IsTrue(WaitFor(() => client.CallCount == 1), "expected the client to be invoked");
             Assert.AreEqual("my-event", client.LastEvent.Type);
             Assert.AreEqual("user-1", client.LastUser.UserId);
-            Assert.AreEqual(0, logger.Entries.Count, "no errors expected on the success path");
+            Assert.AreEqual(0, logger.Entries.Count, "no warnings expected on the success path");
         }
 
-        private static LogEntry WaitForError(CapturingLogger logger)
+        private static LogEntry WaitForWarning(CapturingLogger logger)
         {
             WaitFor(() => logger.Entries.Count > 0);
-            return logger.Entries.FirstOrDefault(entry => entry.Level == LogLevel.Error);
+            return logger.Entries.FirstOrDefault(entry => entry.Level == LogLevel.Warning);
         }
 
         private static bool WaitFor(Func<bool> condition)

--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Common.API;
 using DevCycle.SDK.Server.Common.Model;
@@ -128,7 +129,7 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
             while (stopwatch.Elapsed < LogWaitTimeout)
             {
                 if (condition()) return true;
-                Task.Delay(10).Wait();
+                Thread.Sleep(10);
             }
 
             return condition();

--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using DevCycle.SDK.Server.Common.API;
+using DevCycle.SDK.Server.Common.Model;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenFeature.Model;
+
+namespace DevCycle.SDK.Server.Cloud.MSTests
+{
+    /// <summary>
+    /// Covers the fire-and-forget contract of <see cref="DevCycleProvider.Track"/>. The method
+    /// must never throw at the call site and must never let an exception escape onto the thread
+    /// pool, which is what an <c>async void</c> implementation would do (terminating the process).
+    /// </summary>
+    [TestClass]
+    public class DevCycleProviderTrackTest
+    {
+        private static readonly TimeSpan LogWaitTimeout = TimeSpan.FromSeconds(5);
+
+        [TestMethod]
+        public void Track_WhenClientTrackThrows_DoesNotThrowAndLogsError()
+        {
+            var logger = new CapturingLogger();
+            var client = new ThrowingTrackClient(new InvalidOperationException("track boom"));
+            var provider = new DevCycleProvider(client, logger);
+
+            var context = EvaluationContext.Builder().SetTargetingKey("user-1").Build();
+
+            provider.Track("my-event", context, TrackingEventDetails.Empty);
+
+            var entry = WaitForError(logger);
+            Assert.IsNotNull(entry, "expected a logged error for the failed tracking call");
+            StringAssert.Contains(entry.Message, "my-event");
+            Assert.IsInstanceOfType(entry.Exception, typeof(InvalidOperationException));
+        }
+
+        [TestMethod]
+        public void Track_WithNullEvaluationContext_DoesNotThrowAndLogsError()
+        {
+            var logger = new CapturingLogger();
+            var client = new RecordingTrackClient();
+            var provider = new DevCycleProvider(client, logger);
+
+            provider.Track("my-event", null, TrackingEventDetails.Empty);
+
+            var entry = WaitForError(logger);
+            Assert.IsNotNull(entry, "expected a logged error for the null evaluation context");
+            Assert.AreEqual(0, client.CallCount, "client should not be called when context conversion fails");
+        }
+
+        [TestMethod]
+        public void Track_WithContextMissingTargetingKey_DoesNotThrowAndLogsError()
+        {
+            var logger = new CapturingLogger();
+            var client = new RecordingTrackClient();
+            var provider = new DevCycleProvider(client, logger);
+
+            var context = EvaluationContext.Builder().Set("email", "test@example.com").Build();
+
+            provider.Track("my-event", context, TrackingEventDetails.Empty);
+
+            var entry = WaitForError(logger);
+            Assert.IsNotNull(entry, "expected a logged error for the missing targeting key");
+            Assert.AreEqual(0, client.CallCount, "client should not be called when context conversion fails");
+        }
+
+        [TestMethod]
+        public void Track_WithNullTrackingEventDetails_DoesNotThrowAndLogsError()
+        {
+            var logger = new CapturingLogger();
+            var client = new RecordingTrackClient();
+            var provider = new DevCycleProvider(client, logger);
+
+            var context = EvaluationContext.Builder().SetTargetingKey("user-1").Build();
+
+            provider.Track("my-event", context, null);
+
+            var entry = WaitForError(logger);
+            Assert.IsNotNull(entry, "expected a logged error for the null tracking event details");
+            Assert.AreEqual(0, client.CallCount, "client should not be called when event conversion fails");
+        }
+
+        [TestMethod]
+        public void Track_WithNullLogger_DoesNotThrow()
+        {
+            var client = new ThrowingTrackClient(new InvalidOperationException("track boom"));
+            var provider = new DevCycleProvider(client);
+
+            var context = EvaluationContext.Builder().SetTargetingKey("user-1").Build();
+
+            // A provider built without a logger must still swallow the failure rather than
+            // faulting the thread pool.
+            provider.Track("my-event", context, TrackingEventDetails.Empty);
+
+            Assert.IsTrue(WaitFor(() => client.CallCount == 1), "expected the client to be invoked");
+        }
+
+        [TestMethod]
+        public void Track_OnSuccess_ForwardsEventNameAndUserToClient()
+        {
+            var logger = new CapturingLogger();
+            var client = new RecordingTrackClient();
+            var provider = new DevCycleProvider(client, logger);
+
+            var context = EvaluationContext.Builder().SetTargetingKey("user-1").Build();
+
+            provider.Track("my-event", context, TrackingEventDetails.Empty);
+
+            Assert.IsTrue(WaitFor(() => client.CallCount == 1), "expected the client to be invoked");
+            Assert.AreEqual("my-event", client.LastEvent.Type);
+            Assert.AreEqual("user-1", client.LastUser.UserId);
+            Assert.AreEqual(0, logger.Entries.Count, "no errors expected on the success path");
+        }
+
+        private static LogEntry WaitForError(CapturingLogger logger)
+        {
+            WaitFor(() => logger.Entries.Count > 0);
+            return logger.Entries.FirstOrDefault(entry => entry.Level == LogLevel.Error);
+        }
+
+        private static bool WaitFor(Func<bool> condition)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            while (stopwatch.Elapsed < LogWaitTimeout)
+            {
+                if (condition()) return true;
+                Task.Delay(10).Wait();
+            }
+
+            return condition();
+        }
+
+        private class LogEntry
+        {
+            public LogLevel Level { get; set; }
+            public string Message { get; set; }
+            public Exception Exception { get; set; }
+        }
+
+        private class CapturingLogger : ILogger
+        {
+            private readonly List<LogEntry> entries = new List<LogEntry>();
+
+            public IReadOnlyList<LogEntry> Entries
+            {
+                get
+                {
+                    lock (entries)
+                    {
+                        return entries.ToList();
+                    }
+                }
+            }
+
+            public IDisposable BeginScope<TState>(TState state) => new NoopScope();
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                lock (entries)
+                {
+                    entries.Add(new LogEntry
+                    {
+                        Level = logLevel,
+                        Message = formatter(state, exception),
+                        Exception = exception
+                    });
+                }
+            }
+
+            private class NoopScope : IDisposable
+            {
+                public void Dispose()
+                {
+                }
+            }
+        }
+
+        /// <summary>
+        /// Minimal <see cref="DevCycleBaseClient"/> stub; only <c>Track</c> is exercised.
+        /// </summary>
+        private abstract class StubClient : DevCycleBaseClient
+        {
+            public override void Dispose()
+            {
+            }
+
+            public override string Platform() => "Test";
+
+            public override IDevCycleApiClient GetApiClient() => throw new NotImplementedException();
+
+            public override DevCycleProvider GetOpenFeatureProvider() => throw new NotImplementedException();
+
+            public override Task<Dictionary<string, Feature>> AllFeatures(DevCycleUser user) =>
+                throw new NotImplementedException();
+
+            public override Task<Dictionary<string, ReadOnlyVariable<object>>> AllVariables(DevCycleUser user) =>
+                throw new NotImplementedException();
+
+            public override Task<Variable<T>> Variable<T>(DevCycleUser user, string key, T defaultValue) =>
+                throw new NotImplementedException();
+
+            public override Task<T> VariableValue<T>(DevCycleUser user, string key, T defaultValue) =>
+                throw new NotImplementedException();
+        }
+
+        private class ThrowingTrackClient : StubClient
+        {
+            private readonly Exception toThrow;
+
+            public ThrowingTrackClient(Exception toThrow)
+            {
+                this.toThrow = toThrow;
+            }
+
+            public int CallCount { get; private set; }
+
+            public override Task<DevCycleResponse> Track(DevCycleUser user, DevCycleEvent userEvent)
+            {
+                CallCount++;
+                throw toThrow;
+            }
+        }
+
+        private class RecordingTrackClient : StubClient
+        {
+            public int CallCount { get; private set; }
+            public DevCycleUser LastUser { get; private set; }
+            public DevCycleEvent LastEvent { get; private set; }
+
+            public override Task<DevCycleResponse> Track(DevCycleUser user, DevCycleEvent userEvent)
+            {
+                LastUser = user;
+                LastEvent = userEvent;
+                CallCount++;
+                return Task.FromResult(new DevCycleResponse("ok"));
+            }
+        }
+    }
+}

--- a/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
+++ b/DevCycle.SDK.Server.Cloud.MSTests/DevCycleProviderTrackTest.cs
@@ -86,6 +86,24 @@ namespace DevCycle.SDK.Server.Cloud.MSTests
         }
 
         [TestMethod]
+        public void Track_WithNullEventName_DoesNotThrowAndLogsWarning()
+        {
+            var logger = new CapturingLogger();
+            var client = new RecordingTrackClient();
+            var provider = new DevCycleProvider(client, logger);
+
+            var context = EvaluationContext.Builder().SetTargetingKey("user-1").Build();
+
+            // DevCycleEvent requires a type, so a null event name must be rejected rather than
+            // sent to the client as a blank type.
+            provider.Track(null, context, TrackingEventDetails.Empty);
+
+            var entry = WaitForWarning(logger);
+            Assert.IsNotNull(entry, "expected a logged warning for the null event name");
+            Assert.AreEqual(0, client.CallCount, "client should not be called when the event name is missing");
+        }
+
+        [TestMethod]
         public void Track_WithNullLogger_DoesNotThrow()
         {
             var client = new ThrowingTrackClient(new InvalidOperationException("track boom"));

--- a/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
+++ b/DevCycle.SDK.Server.Cloud/Api/DevCycleCloudClient.cs
@@ -44,7 +44,7 @@ namespace DevCycle.SDK.Server.Cloud.Api
             apiClient = new DevCycleApiClient(sdkKey, restClientOptions);
             logger = loggerFactory.CreateLogger<DevCycleCloudClient>();
             this.options = options != null ? (DevCycleCloudOptions)options : new DevCycleCloudOptions();
-            OpenFeatureProvider = new DevCycleProvider(this);
+            OpenFeatureProvider = new DevCycleProvider(this, logger);
             evalHooksRunner = new EvalHooksRunner(logger, this.options.EvalHooks);
         }
 

--- a/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
+++ b/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
@@ -8,6 +8,9 @@ using Newtonsoft.Json.Linq;
 using OpenFeature;
 using OpenFeature.Constant;
 using OpenFeature.Model;
+// DevCycle.SDK.Server.Common has a child namespace named Exception, which shadows the type here,
+// so System.Exception needs an alias to be referenced by a simple name.
+using SysException = System.Exception;
 
 namespace DevCycle.SDK.Server.Common.API
 {
@@ -55,7 +58,7 @@ namespace DevCycle.SDK.Server.Common.API
             CancellationToken cancellationToken = new CancellationToken())
         {
             if (!defaultValue.IsStructure)
-                throw new System.Exception("Cannot call ResolveStructureValue with non-structure Value's");
+                throw new SysException("Cannot call ResolveStructureValue with non-structure Value's");
             var jsonString = JsonSerializer.Serialize(defaultValue,
                 new JsonSerializerOptions() { Converters = { new OpenFeatureValueJsonConverter() } });
 
@@ -94,7 +97,7 @@ namespace DevCycle.SDK.Server.Common.API
                     e.Type = trackingEventName;
                     await Client.Track(DevCycleUser.FromEvaluationContext(evaluationContext), e);
                 }
-                catch (System.Exception ex)
+                catch (SysException ex)
                 {
                     logger?.LogWarning(ex, "Failed to track OpenFeature event {EventName}", trackingEventName);
                 }

--- a/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
+++ b/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
@@ -96,7 +96,7 @@ namespace DevCycle.SDK.Server.Common.API
                 }
                 catch (System.Exception ex)
                 {
-                    logger?.LogError(ex, "Failed to track OpenFeature event {EventName}", trackingEventName);
+                    logger?.LogWarning(ex, "Failed to track OpenFeature event {EventName}", trackingEventName);
                 }
             });
         }

--- a/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
+++ b/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DevCycle.SDK.Server.Common.Model;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using OpenFeature;
 using OpenFeature.Constant;
@@ -13,10 +14,12 @@ namespace DevCycle.SDK.Server.Common.API
     public class DevCycleProvider : FeatureProvider
     {
         private DevCycleBaseClient Client { get; }
+        private readonly ILogger logger;
 
-        public DevCycleProvider(DevCycleBaseClient client)
+        public DevCycleProvider(DevCycleBaseClient client, ILogger logger = null)
         {
             Client = client;
+            this.logger = logger;
         }
 
         public override Metadata GetMetadata()
@@ -73,12 +76,29 @@ namespace DevCycle.SDK.Server.Common.API
             return Task.CompletedTask;
         }
 
-        public override async void Track(string trackingEventName, EvaluationContext evaluationContext = null,
+        /// <summary>
+        /// Tracks an event against the DevCycle client. The OpenFeature tracking API is
+        /// fire-and-forget and returns void, so the work is dispatched to the thread pool and
+        /// any failure is logged rather than surfaced to the caller. This must never be
+        /// <c>async void</c>: an exception escaping an <c>async void</c> method is rethrown on
+        /// the thread pool and terminates the host process.
+        /// </summary>
+        public override void Track(string trackingEventName, EvaluationContext evaluationContext = null,
             TrackingEventDetails trackingEventDetails = null)
         {
-            var e = DevCycleEvent.FromTrackingEventDetails(trackingEventDetails);
-            e.Type = trackingEventName;
-            await Client.Track(DevCycleUser.FromEvaluationContext(evaluationContext), e);
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var e = DevCycleEvent.FromTrackingEventDetails(trackingEventDetails);
+                    e.Type = trackingEventName;
+                    await Client.Track(DevCycleUser.FromEvaluationContext(evaluationContext), e);
+                }
+                catch (System.Exception ex)
+                {
+                    logger?.LogError(ex, "Failed to track OpenFeature event {EventName}", trackingEventName);
+                }
+            });
         }
 
         private async Task<ResolutionDetails<T>> EvaluateDevCycle<T>(string flagKey, T defaultValue,

--- a/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
+++ b/DevCycle.SDK.Server.Common/API/DevCycleProvider.cs
@@ -93,8 +93,7 @@ namespace DevCycle.SDK.Server.Common.API
             {
                 try
                 {
-                    var e = DevCycleEvent.FromTrackingEventDetails(trackingEventDetails);
-                    e.Type = trackingEventName;
+                    var e = DevCycleEvent.FromTrackingEventDetails(trackingEventDetails, trackingEventName);
                     await Client.Track(DevCycleUser.FromEvaluationContext(evaluationContext), e);
                 }
                 catch (SysException ex)

--- a/DevCycle.SDK.Server.Common/Model/DevCycleEvent.cs
+++ b/DevCycle.SDK.Server.Common/Model/DevCycleEvent.cs
@@ -32,12 +32,14 @@ namespace DevCycle.SDK.Server.Common.Model
             MetaData = metaData;
         }
 
-        public static DevCycleEvent FromTrackingEventDetails(TrackingEventDetails trackingEventDetails)
+        /// <summary>
+        /// Builds an event from OpenFeature tracking event details.
+        /// </summary>
+        /// <param name="trackingEventDetails">The OpenFeature tracking event details.</param>
+        /// <param name="type">The tracking event name, required as the event type.</param>
+        public static DevCycleEvent FromTrackingEventDetails(TrackingEventDetails trackingEventDetails, string type)
         {
-            // Type is required by the constructor, and is set by the caller from the OpenFeature
-            // tracking event name once this event has been built. Passing an empty string keeps
-            // the constructor's null check from rejecting the placeholder.
-            var ret = new DevCycleEvent(string.Empty);
+            var ret = new DevCycleEvent(type);
             var metadata = new Dictionary<string, object>();
             ret.Value = trackingEventDetails.Value ?? 0;
             foreach (var keyValuePair in trackingEventDetails.AsDictionary())

--- a/DevCycle.SDK.Server.Common/Model/DevCycleEvent.cs
+++ b/DevCycle.SDK.Server.Common/Model/DevCycleEvent.cs
@@ -34,7 +34,10 @@ namespace DevCycle.SDK.Server.Common.Model
 
         public static DevCycleEvent FromTrackingEventDetails(TrackingEventDetails trackingEventDetails)
         {
-            var ret = new DevCycleEvent();
+            // Type is required by the constructor, and is set by the caller from the OpenFeature
+            // tracking event name once this event has been built. Passing an empty string keeps
+            // the constructor's null check from rejecting the placeholder.
+            var ret = new DevCycleEvent(string.Empty);
             var metadata = new Dictionary<string, object>();
             ret.Value = trackingEventDetails.Value ?? 0;
             foreach (var keyValuePair in trackingEventDetails.AsDictionary())

--- a/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
+++ b/DevCycle.SDK.Server.Local/Api/DevCycleLocalClient.cs
@@ -108,7 +108,7 @@ namespace DevCycle.SDK.Server.Local.Api
             timer.AutoReset = true;
             timer.Enabled = true;
             Task.Run(async delegate { await this.configManager.InitializeConfigAsync(); });
-            OpenFeatureProvider = new DevCycleProvider(this);
+            OpenFeatureProvider = new DevCycleProvider(this, logger);
         }
 
         private void OnTimedEvent(object source, ElapsedEventArgs e)


### PR DESCRIPTION
## Summary

- `DevCycleProvider.Track` was `async void`, so any exception it threw was rethrown outside the caller's control: on the thread pool where there is no `SynchronizationContext` (.NET Core, ASP.NET Core), which terminates the process. It is now `void`, dispatching the work explicitly and logging failures.
- Fixed `DevCycleEvent.FromTrackingEventDetails`, which built its result with `new DevCycleEvent()`. That constructor's `type` parameter defaults to `null` and is required, so the call threw `InvalidDataException` before reaching the client. It now constructs with `string.Empty`, which `Track` overwrites with the tracking event name on the next line. This is scoped to the provider's `Track`; the native `Client.Track` API is unaffected.
- Added an optional `ILogger` to the `DevCycleProvider` constructor, passed through by both concrete clients from the factory they already build. Existing callers passing only the client keep compiling.
- Added 6 tests to a path that had none. Cloud suite goes from 14 to 20 passing; Local stays at 52.

The two are worth fixing together: the second is what made the `async void` path reachable on every provider `Track` call rather than only on transport errors.

We can't just return `Task`: the base `FeatureProvider.Track` returns `void`, and OpenFeature tracking is fire-and-forget by spec. Only `async` was ours to remove.

### Notes

- `Task.Run` moves the work off the caller's thread, so `HttpContext`, `CultureInfo`, and `AsyncLocal` no longer flow. Both conversion helpers are pure, so nothing depends on the calling context.
- Under a host that has a `SynchronizationContext` (legacy ASP.NET, WinForms, WPF), tracking failures become a log line instead of surfacing. That's the intent, but it's a visibility reduction.
- Stacked on #206. The `async void` predates that PR, so this can be retargeted at `main` if you'd prefer it standalone.
- `DevCycleEvent`'s constructor also has a `ClientDate = ClientDate;` self-assignment that discards the argument. Fixing it changes serialized payloads, so I left it for its own PR.
