### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     name: build, pack & publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/semantic-prs.yml
+++ b/.github/workflows/semantic-prs.yml
@@ -15,6 +15,6 @@ jobs:
         name: Semantic PR title
         runs-on: ubuntu-latest
         steps:
-            - uses: amannn/action-semantic-pull-request@v6
+            - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-prs.yml
+++ b/.github/workflows/semantic-prs.yml
@@ -15,6 +15,6 @@ jobs:
         name: Semantic PR title
         runs-on: ubuntu-latest
         steps:
-            - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825
+            - uses: amannn/action-semantic-pull-request@v6
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-run-examples.yml
+++ b/.github/workflows/test-run-examples.yml
@@ -17,9 +17,9 @@ jobs:
   run-example:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version:  "8.0.x"
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
           include-prerelease: true


### PR DESCRIPTION
## Summary

- Update GitHub Actions and custom action dependencies to Node 24-compatible releases.
- Update nested dependencies in composite and custom actions.
- Retain actions without an available Node 24 release.